### PR TITLE
Fix bug when provided grip uri ends with slash

### DIFF
--- a/lib/pubcontrolclient.js
+++ b/lib/pubcontrolclient.js
@@ -72,7 +72,7 @@ var PubControlClient = utilities.defineClass(function(uri) {
             headers['Authorization'] = authHeader;
         }
         // Build HTTP request parameters
-        var publishUri = uri + '/publish/';
+        var publishUri = uri.replace(/\/$/, '') + '/publish/';
         var reqParams = utilities.extend(url.parse(publishUri), {
             method: 'POST',
             headers: headers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pubcontrol",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "author": "Fanout, Inc. <info@fanout.io>",
     "description": "EPCP Library",
     "contributors": [


### PR DESCRIPTION
It would build urls like 'localhost:5661//events' and error