### PR TITLE
Modernize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ jobs:
     - stage: test
       script:
         - (cd etc/browser-demo && make)
+    - stage: test
+      script: npm run lint

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var callback = function(success, message, context) {
 var pub = new pubcontrol.PubControl({
         'uri': 'https://api.fanout.io/realm/<myrealm>',
         'iss': '<myrealm>',
-        'key': new Buffer('<myrealmkey', 'base64')});
+        'key': Buffer.from('<myrealmkey', 'base64')});
 
 // Add new endpoints by applying an endpoint configuration:
 pub.applyConfig([{'uri': '<myendpoint_uri_1>'},

--- a/etc/browser-demo/src/test.js
+++ b/etc/browser-demo/src/test.js
@@ -4,7 +4,7 @@ import { inherits } from "util";
 const defaultOpts = {
   uri: "http://api.webhookinbox.com/i/K1BiRnDW/in/",
   iss: "testPubControl defaultOpts Issuer",
-  key: new Buffer("testPubControl defaultOpts realmKey", "base64"),
+  key: Buffer.from("testPubControl defaultOpts realmKey", "base64"),
   defaultChannel: "testPubcontrol defaultOpts defaultChannel"
 };
 
@@ -20,7 +20,7 @@ async function testFromReadme({ uri, iss, key, defaultChannel }) {
   // const pub = new PubControl({
   //   'uri': 'https://api.fanout.io/realm/<myrealm>',
   //   'iss': '<myrealm>',
-  //   'key': new Buffer('<myrealmkey', 'base64')
+  //   'key': Buffer.from('<myrealmkey', 'base64')
   // });
   const pub = new PubControl({ uri, iss, key });
   // var pubclient = new PubControlClient('<myendpoint_uri>');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -51,7 +51,7 @@ class AuthJwt extends AuthBase {
       this.key = null;
     } else {
       this.claim = claim;
-      this.key = utilities.toBuffer(key);
+      this.key = key instanceof Buffer ? key : Buffer.from(String(key), "utf8");
       this.token = null;
     }
   }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -61,14 +61,12 @@ class AuthJwt extends AuthBase {
     if (this.token != null) {
       token = this.token;
     } else {
-      var claim;
-      if (!("exp" in this.claim)) {
-        claim = utilities.extend({}, this.claim, {
-          exp: Math.floor(new Date().getTime() / 1000) + 600
-        });
-      } else {
-        claim = this.claim;
-      }
+      const claim =
+        "exp" in this.claim
+          ? this.claim
+          : Object.assign({}, this.claim, {
+              exp: Math.floor(new Date().getTime() / 1000) + 600
+            });
       token = jwt.encode(claim, this.key);
     }
     return "Bearer " + token;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -33,7 +33,7 @@ class AuthBasic extends AuthBase {
   // in Basic auth format.
   buildHeader() {
     var data = this.user + ":" + this.pass;
-    return "Basic " + new Buffer(data).toString("base64");
+    return "Basic " + Buffer.from(data).toString("base64");
   }
 }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,38 +15,34 @@ var utilities = require("./utilities");
 
 // The authorization base class for building auth headers in conjunction
 // with HTTP requests used for publishing messages.
-var AuthBase = utilities.defineClass({
+class AuthBase {
   // This method should return the auth header in text format.
-  buildHeader: function() {
+  buildHeader() {
     return null;
   }
-});
+}
 
-// The basic authentication class used for building auth headers containing
-// a username and password.
-var AuthBasic = utilities.extendClass(
-  AuthBase,
-  function(user, pass) {
+class AuthBasic extends AuthBase {
+  constructor(user, pass) {
+    super();
     // Initialize with a username and password.
     this.user = user;
     this.pass = pass;
-  },
-  {
-    // Returns the auth header containing the username and password
-    // in Basic auth format.
-    buildHeader: function() {
-      var data = this.user + ":" + this.pass;
-      return "Basic " + new Buffer(data).toString("base64");
-    }
   }
-);
+  // Returns the auth header containing the username and password
+  // in Basic auth format.
+  buildHeader() {
+    var data = this.user + ":" + this.pass;
+    return "Basic " + new Buffer(data).toString("base64");
+  }
+}
 
 // JWT authentication class used for building auth headers containing
 // JSON web token information in either the form of a claim and
 // corresponding key, or the literal token itself.
-var AuthJwt = utilities.extendClass(
-  AuthBase,
-  function(claim, key) {
+class AuthJwt extends AuthBase {
+  constructor(claim, key) {
+    super();
     // Initialize with the specified claim and key. If only one parameter
     // was provided then treat it as the literal token.
     if (arguments.length == 1) {
@@ -58,28 +54,26 @@ var AuthJwt = utilities.extendClass(
       this.key = utilities.toBuffer(key);
       this.token = null;
     }
-  },
-  {
-    // Returns the auth header containing the JWT token in Bearer format.
-    buildHeader: function() {
-      var token;
-      if (this.token != null) {
-        token = this.token;
-      } else {
-        var claim;
-        if (!("exp" in this.claim)) {
-          claim = utilities.extend({}, this.claim, {
-            exp: Math.floor(new Date().getTime() / 1000) + 600
-          });
-        } else {
-          claim = this.claim;
-        }
-        token = jwt.encode(claim, this.key);
-      }
-      return "Bearer " + token;
-    }
   }
-);
+  // Returns the auth header containing the JWT token in Bearer format.
+  buildHeader() {
+    var token;
+    if (this.token != null) {
+      token = this.token;
+    } else {
+      var claim;
+      if (!("exp" in this.claim)) {
+        claim = utilities.extend({}, this.claim, {
+          exp: Math.floor(new Date().getTime() / 1000) + 600
+        });
+      } else {
+        claim = this.claim;
+      }
+      token = jwt.encode(claim, this.key);
+    }
+    return "Bearer " + token;
+  }
+}
 
 exports.AuthBase = AuthBase;
 exports.AuthBasic = AuthBasic;

--- a/lib/format.js
+++ b/lib/format.js
@@ -14,18 +14,17 @@ var utilities = require("./utilities");
 // The Format class is provided as a base class for all publishing
 // formats that are included in the Item class. Examples of format
 // implementations include JsonObjectFormat and HttpStreamFormat.
-var Format = utilities.defineClass({
+class Format {
   // The name of the format which should return a string. Examples
   // include 'json-object' and 'http-response'
-  name: function() {
-    return null;
-  },
-
-  // The export method which should return a format-specific hash
-  // containing the required format-specific data.
-  export: function() {
+  name() {
     return null;
   }
-});
+  // The export method which should return a format-specific hash
+  // containing the required format-specific data.
+  export() {
+    return null;
+  }
+}
 
 exports.Format = Format;

--- a/lib/item.js
+++ b/lib/item.js
@@ -22,7 +22,7 @@ class Item {
     // instance or an array of Format implementation instances. Optionally
     // specify an ID and/or previous ID to be sent as part of the message
     // published to the client.
-    var formats = utilities.isArray(formats) ? formats : [formats];
+    var formats = Array.isArray(formats) ? formats : [formats];
     this.formats = formats;
     if (arguments.length >= 3) {
       this.prevId = prevId;

--- a/lib/item.js
+++ b/lib/item.js
@@ -16,8 +16,8 @@ var utilities = require("./utilities");
 // different type of format. An Item instance may not contain multiple
 // implementations of the same type of format. An Item instance is then
 // serialized into a hash that is used for publishing to clients.
-var Item = utilities.defineClass(
-  function(formats, id, prevId) {
+class Item {
+  constructor(formats, id, prevId) {
     // The initialize method can accept either a single Format implementation
     // instance or an array of Format implementation instances. Optionally
     // specify an ID and/or previous ID to be sent as part of the message
@@ -30,36 +30,34 @@ var Item = utilities.defineClass(
     if (arguments.length >= 2) {
       this.id = id;
     }
-  },
-  {
-    // The export method serializes all of the formats, ID, and previous ID
-    // into a hash that is used for publishing to clients. If more than one
-    // instance of the same type of Format implementation was specified then
-    // an error will be raised.
-    export: function() {
-      var formatNames = [];
-      this.formats.forEach(function(format) {
-        var formatName = format.name();
-        if (formatNames.indexOf(formatName) >= 0) {
-          throw new Error(
-            "More than one instance of " + formatName + " specified"
-          );
-        }
-        formatNames.push(formatName);
-      });
-      var obj = {};
-      if ("id" in this) {
-        obj["id"] = this.id;
-      }
-      if ("prevId" in this) {
-        obj["prev-id"] = this.prevId;
-      }
-      this.formats.forEach(function(format) {
-        obj[format.name()] = format.export();
-      });
-      return obj;
-    }
   }
-);
+  // The export method serializes all of the formats, ID, and previous ID
+  // into a hash that is used for publishing to clients. If more than one
+  // instance of the same type of Format implementation was specified then
+  // an error will be raised.
+  export() {
+    var formatNames = [];
+    this.formats.forEach(function(format) {
+      var formatName = format.name();
+      if (formatNames.indexOf(formatName) >= 0) {
+        throw new Error(
+          "More than one instance of " + formatName + " specified"
+        );
+      }
+      formatNames.push(formatName);
+    });
+    var obj = {};
+    if ("id" in this) {
+      obj["id"] = this.id;
+    }
+    if ("prevId" in this) {
+      obj["prev-id"] = this.prevId;
+    }
+    this.formats.forEach(function(format) {
+      obj[format.name()] = format.export();
+    });
+    return obj;
+  }
+}
 
 exports.Item = Item;

--- a/lib/pcccbhandler.js
+++ b/lib/pcccbhandler.js
@@ -19,8 +19,8 @@ var utilities = require("./utilities");
 // instances. A failure to publish in any of the PubControlClient instances
 // will result in a failed result passed to the callback method and the error
 // from the first encountered failure.
-var PubControlClientCallbackHandler = utilities.defineClass(
-  function(numCalls, callback) {
+class PubControlClientCallbackHandler {
+  constructor(numCalls, callback) {
     // The initialize method accepts: a num_calls parameter which is an integer
     // representing the number of PubControlClient instances, and a callback
     // method to be executed after all publishing is complete.
@@ -29,37 +29,34 @@ var PubControlClientCallbackHandler = utilities.defineClass(
     this.success = true;
     this.firstErrorMessage = null;
     this.firstErrorContext = null;
-  },
-  {
-    // Helper method for determining whether the object is an instance
-    // of PubControlClientCallbackHandler.
-    isPubControlClientCallbackHandler: function() {
-      return true;
-    },
-
-    // The handler method which is executed by PubControlClient when publishing
-    // is complete. This method tracks the number of publishes performed and
-    // when all publishes are complete it will call the callback method
-    // originally specified by the consumer. If publishing failures are
-    // encountered only the first error is saved and reported to the callback
-    // method.
-    pubControlClientCallbackHandler: function(success, message, context) {
-      if (!success && this.success) {
-        this.success = false;
-        this.firstErrorMessage = message;
-        this.firstErrorContext = context;
-      }
-      this.numCalls -= 1;
-      if (this.numCalls <= 0) {
-        utilities.applyCallback(
-          this.success,
-          this.callback,
-          this.firstErrorMessage,
-          this.firstErrorContext
-        );
-      }
+  }
+  // Helper method for determining whether the object is an instance
+  // of PubControlClientCallbackHandler.
+  isPubControlClientCallbackHandler() {
+    return true;
+  }
+  // The handler method which is executed by PubControlClient when publishing
+  // is complete. This method tracks the number of publishes performed and
+  // when all publishes are complete it will call the callback method
+  // originally specified by the consumer. If publishing failures are
+  // encountered only the first error is saved and reported to the callback
+  // method.
+  pubControlClientCallbackHandler(success, message, context) {
+    if (!success && this.success) {
+      this.success = false;
+      this.firstErrorMessage = message;
+      this.firstErrorContext = context;
+    }
+    this.numCalls -= 1;
+    if (this.numCalls <= 0) {
+      utilities.applyCallback(
+        this.success,
+        this.callback,
+        this.firstErrorMessage,
+        this.firstErrorContext
+      );
     }
   }
-);
+}
 
 exports.PubControlClientCallbackHandler = PubControlClientCallbackHandler;

--- a/lib/pubcontrol.js
+++ b/lib/pubcontrol.js
@@ -19,8 +19,8 @@ var pubControlClient = require("./pubcontrolclient");
 // method call. A PubControl instance can be configured either using a
 // hash or array of hashes containing configuration information or by
 // manually adding PubControlClient instances.
-var PubControl = utilities.defineClass(
-  function(config) {
+class PubControl {
+  constructor(config) {
     // Initialize with or without a configuration. A configuration can be applied
     // after initialization via the apply_config method.
     if (arguments.length == 1) {
@@ -28,61 +28,57 @@ var PubControl = utilities.defineClass(
     } else {
       this.clients = [];
     }
-  },
-  {
-    // Remove all of the configured PubControlClient instances.
-    removeAllClients: function() {
-      this.clients = [];
-    },
-
-    // Add the specified PubControlClient instance.
-    addClient: function(client) {
-      this.clients.push(client);
-    },
-
-    // Apply the specified configuration to this PubControl instance. The
-    // configuration object can either be a hash or an array of hashes where
-    // each hash corresponds to a single PubControlClient instance. Each hash
-    // will be parsed and a PubControlClient will be created either using just
-    // a URI or a URI and JWT authentication information.
-    applyConfig: function(config) {
-      var clients = [];
-      if (typeof this.clients !== "undefined") {
-        clients = this.clients;
-      }
-      var config = utilities.isArray(config) ? config : [config];
-      config.forEach(function(entry) {
-        var client = new pubControlClient.PubControlClient(entry["uri"]);
-        if ("iss" in entry) {
-          client.setAuthJwt({ iss: entry["iss"] }, entry["key"]);
-        }
-        clients.push(client);
-      });
-      this.clients = clients;
-    },
-
-    // The publish method for publishing the specified item to the specified
-    // channel on the configured endpoint. The callback method is optional
-    // and will be passed the publishing results after publishing is complete.
-    // Note that a failure to publish in any of the configured PubControlClient
-    // instances will result in a failure result being passed to the callback
-    // method along with the first encountered error message.
-    publish: function(channel, item, cb) {
-      // TODO: Figure out how to pass the callback itself while avoiding
-      // the pcccbhandler instance issue.
-      var pcccbhandler = null;
-      if (utilities.isFunction(cb)) {
-        pcccbhandler = new pcccbHandler.PubControlClientCallbackHandler(
-          this.clients.length,
-          cb
-        );
-      }
-      this.clients.forEach(function(client) {
-        client.publish(channel, item, pcccbhandler);
-      });
-    }
   }
-);
+  // Remove all of the configured PubControlClient instances.
+  removeAllClients() {
+    this.clients = [];
+  }
+  // Add the specified PubControlClient instance.
+  addClient(client) {
+    this.clients.push(client);
+  }
+  // Apply the specified configuration to this PubControl instance. The
+  // configuration object can either be a hash or an array of hashes where
+  // each hash corresponds to a single PubControlClient instance. Each hash
+  // will be parsed and a PubControlClient will be created either using just
+  // a URI or a URI and JWT authentication information.
+  applyConfig(config) {
+    var clients = [];
+    if (typeof this.clients !== "undefined") {
+      clients = this.clients;
+    }
+    var config = utilities.isArray(config) ? config : [config];
+    config.forEach(function(entry) {
+      var client = new pubControlClient.PubControlClient(entry["uri"]);
+      if ("iss" in entry) {
+        client.setAuthJwt({ iss: entry["iss"] }, entry["key"]);
+      }
+      clients.push(client);
+    });
+    this.clients = clients;
+  }
+
+  // The publish method for publishing the specified item to the specified
+  // channel on the configured endpoint. The callback method is optional
+  // and will be passed the publishing results after publishing is complete.
+  // Note that a failure to publish in any of the configured PubControlClient
+  // instances will result in a failure result being passed to the callback
+  // method along with the first encountered error message.
+  publish(channel, item, cb) {
+    // TODO: Figure out how to pass the callback itself while avoiding
+    // the pcccbhandler instance issue.
+    var pcccbhandler = null;
+    if (utilities.isFunction(cb)) {
+      pcccbhandler = new pcccbHandler.PubControlClientCallbackHandler(
+        this.clients.length,
+        cb
+      );
+    }
+    this.clients.forEach(function(client) {
+      client.publish(channel, item, pcccbhandler);
+    });
+  }
+}
 
 exports.Format = format.Format;
 exports.Item = item.Item;

--- a/lib/pubcontrol.js
+++ b/lib/pubcontrol.js
@@ -68,7 +68,7 @@ class PubControl {
     // TODO: Figure out how to pass the callback itself while avoiding
     // the pcccbhandler instance issue.
     var pcccbhandler = null;
-    if (utilities.isFunction(cb)) {
+    if (typeof cb === "function") {
       pcccbhandler = new pcccbHandler.PubControlClientCallbackHandler(
         this.clients.length,
         cb

--- a/lib/pubcontrol.js
+++ b/lib/pubcontrol.js
@@ -47,7 +47,7 @@ class PubControl {
     if (typeof this.clients !== "undefined") {
       clients = this.clients;
     }
-    var config = utilities.isArray(config) ? config : [config];
+    var config = Array.isArray(config) ? config : [config];
     config.forEach(function(entry) {
       var client = new pubControlClient.PubControlClient(entry["uri"]);
       if ("iss" in entry) {

--- a/lib/pubcontrolclient.js
+++ b/lib/pubcontrolclient.js
@@ -22,124 +22,115 @@ var auth = require("./auth");
 // instance and passes that to the publish method. The publish method has
 // an optional callback parameter that is called after the publishing is
 // complete to notify the consumer of the result.
-var PubControlClient = utilities.defineClass(
-  function(uri) {
+exports.PubControlClient = class PubControlClientModern {
+  constructor(uri) {
     // Initialize this class with a URL representing the publishing endpoint.
     this.uri = uri.replace(/\/$/, "");
     this.auth = null;
     this.httpKeepAliveAgent = new agentkeepalive();
     this.httpsKeepAliveAgent = new agentkeepalive.HttpsAgent();
-  },
-  {
-    // Call this method and pass a username and password to use basic
-    // authentication with the configured endpoint.
-    setAuthBasic: function(username, password) {
-      this.auth = new auth.AuthBasic(username, password);
-    },
-
-    // Call this method and pass a claim and key to use JWT authentication
-    // with the configured endpoint.
-    setAuthJwt: function(claim, key) {
-      if (key) {
-        this.auth = new auth.AuthJwt(claim, key);
-      } else {
-        this.auth = new auth.AuthJwt(claim);
-      }
-    },
-
-    // The publish method for publishing the specified item to the specified
-    // channel on the configured endpoint. The callback method is optional
-    // and will be passed the publishing results after publishing is complete.
-    publish: function(channel, item, cb) {
-      var i = item.export();
-      i["channel"] = channel;
-      var authHeader = this.auth != null ? this.auth.buildHeader() : null;
-      this.startPubCall(this.uri, authHeader, [i], cb);
-    },
-
-    // An internal method for starting the work required for publishing
-    // a message. Accepts the URI endpoint, authorization header, items
-    // object, and optional callback as parameters.
-    startPubCall: function(uri, authHeader, items, cb) {
-      // Prepare Request Body
-      var content = JSON.stringify({ items: items });
-      // Build HTTP headers
-      var headers = {
-        "Content-Type": "application/json",
-        "Content-Length": Buffer.byteLength(content, "utf8")
-      };
-      if (authHeader != null) {
-        headers["Authorization"] = authHeader;
-      }
-      // Build HTTP request parameters
-      var publishUri = uri + "/publish/";
-      var parsed = url.parse(publishUri);
-      var reqParams = {
-        method: "POST",
-        headers: headers,
-        body: content
-      };
-      switch (parsed.protocol) {
-        case "http:":
-          reqParams.agent = this.httpKeepAliveAgent;
-          break;
-        case "https:":
-          reqParams.agent = this.httpsKeepAliveAgent;
-          break;
-        default:
-          setTimeout(function() {
-            utilities.applyCallback(false, cb, "Bad URI", {
-              statusCode: -2
-            });
-          }, 0);
-          return;
-      }
-      this.performHttpRequest(cb, fetch, publishUri, reqParams);
-    },
-
-    // An internal method for performing the HTTP request for publishing
-    // a message with the specified parameters.
-    performHttpRequest: function(cb, transport, uri, reqParams) {
-      var finishHttpRequest = this.finishHttpRequest;
-      transport(uri, reqParams).then(
-        function(res) {
-          var context = {
-            statusCode: res.status,
-            headers: res.headers
-          };
-          res.text().then(
-            function(data) {
-              finishHttpRequest("end", cb, data, context);
-            },
-            function(err) {
-              finishHttpRequest("close", cb, err, context);
-            }
-          );
-        },
-        function(err) {
-          utilities.applyCallback(false, cb, err.message, {
-            statusCode: -1
-          });
-        }
-      );
-    },
-
-    // An internal method for finishing the HTTP request for publishing
-    // a message.
-    finishHttpRequest: function(mode, cb, httpData, context) {
-      context.httpBody = httpData;
-      var success;
-      var message;
-      if (mode === "end") {
-        success = context.statusCode >= 200 && context.statusCode < 300;
-        message = success ? "" : JSON.stringify(context.httpBody);
-      } else if (mode === "close") {
-        success = false;
-        message = "Connection closed unexpectedly";
-      }
-      utilities.applyCallback(success, cb, message, context);
+  }
+  // Call this method and pass a username and password to use basic
+  // authentication with the configured endpoint.
+  setAuthBasic(username, password) {
+    this.auth = new auth.AuthBasic(username, password);
+  }
+  // Call this method and pass a claim and key to use JWT authentication
+  // with the configured endpoint.
+  setAuthJwt(claim, key) {
+    if (key) {
+      this.auth = new auth.AuthJwt(claim, key);
+    } else {
+      this.auth = new auth.AuthJwt(claim);
     }
   }
-);
-
-exports.PubControlClient = PubControlClient;
+  // The publish method for publishing the specified item to the specified
+  // channel on the configured endpoint. The callback method is optional
+  // and will be passed the publishing results after publishing is complete.
+  publish(channel, item, cb) {
+    var i = item.export();
+    i["channel"] = channel;
+    var authHeader = this.auth != null ? this.auth.buildHeader() : null;
+    this.startPubCall(this.uri, authHeader, [i], cb);
+  }
+  // An internal method for starting the work required for publishing
+  // a message. Accepts the URI endpoint, authorization header, items
+  // object, and optional callback as parameters.
+  startPubCall(uri, authHeader, items, cb) {
+    // Prepare Request Body
+    var content = JSON.stringify({ items: items });
+    // Build HTTP headers
+    var headers = {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(content, "utf8")
+    };
+    if (authHeader != null) {
+      headers["Authorization"] = authHeader;
+    }
+    // Build HTTP request parameters
+    var publishUri = uri + "/publish/";
+    var parsed = url.parse(publishUri);
+    var reqParams = {
+      method: "POST",
+      headers: headers,
+      body: content
+    };
+    switch (parsed.protocol) {
+      case "http:":
+        reqParams.agent = this.httpKeepAliveAgent;
+        break;
+      case "https:":
+        reqParams.agent = this.httpsKeepAliveAgent;
+        break;
+      default:
+        setTimeout(function() {
+          utilities.applyCallback(false, cb, "Bad URI", {
+            statusCode: -2
+          });
+        }, 0);
+        return;
+    }
+    this.performHttpRequest(cb, fetch, publishUri, reqParams);
+  }
+  // An internal method for performing the HTTP request for publishing
+  // a message with the specified parameters.
+  performHttpRequest(cb, transport, uri, reqParams) {
+    var finishHttpRequest = this.finishHttpRequest;
+    transport(uri, reqParams).then(
+      function(res) {
+        var context = {
+          statusCode: res.status,
+          headers: res.headers
+        };
+        res.text().then(
+          function(data) {
+            finishHttpRequest("end", cb, data, context);
+          },
+          function(err) {
+            finishHttpRequest("close", cb, err, context);
+          }
+        );
+      },
+      function(err) {
+        utilities.applyCallback(false, cb, err.message, {
+          statusCode: -1
+        });
+      }
+    );
+  }
+  // An internal method for finishing the HTTP request for publishing
+  // a message.
+  finishHttpRequest(mode, cb, httpData, context) {
+    context.httpBody = httpData;
+    var success;
+    var message;
+    if (mode === "end") {
+      success = context.statusCode >= 200 && context.statusCode < 300;
+      message = success ? "" : JSON.stringify(context.httpBody);
+    } else if (mode === "close") {
+      success = false;
+      message = "Connection closed unexpectedly";
+    }
+    utilities.applyCallback(success, cb, message, context);
+  }
+};

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -11,29 +11,6 @@
 
 var objectToString = Object.prototype.toString;
 
-// Class creation and management methods.
-var extend = function() {
-  var args = Array.prototype.slice.call(arguments);
-
-  var obj;
-  if (args.length > 1) {
-    obj = args.shift();
-  } else {
-    obj = {};
-  }
-
-  while (args.length > 0) {
-    var opts = args.shift();
-    if (opts != null) {
-      for (prop in opts) {
-        obj[prop] = opts[prop];
-      }
-    }
-  }
-
-  return obj;
-};
-
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
 // callback is executed depends on whether the callback object
@@ -48,4 +25,3 @@ var applyCallback = function(status, cb, message, context) {
 
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
-exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -11,12 +11,6 @@
 
 var objectToString = Object.prototype.toString;
 
-// Check if input is a buffer. If not, turn it into a string and then
-// encode the bits of its UTF-8 representation into a new Buffer.
-var toBuffer = function(input) {
-  return Buffer.isBuffer(input) ? input : new Buffer(input.toString(), "utf8");
-};
-
 // Class creation and management methods.
 var extend = function() {
   var args = Array.prototype.slice.call(arguments);
@@ -54,5 +48,4 @@ var applyCallback = function(status, cb, message, context) {
 
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
-exports.toBuffer = toBuffer;
 exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -9,8 +9,6 @@
  * Licensed under the MIT License, see file COPYING for details.
  */
 
-var objectToString = Object.prototype.toString;
-
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
 // callback is executed depends on whether the callback object
@@ -24,4 +22,3 @@ var applyCallback = function(status, cb, message, context) {
 };
 
 exports.applyCallback = applyCallback;
-exports.objectToString = objectToString;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -11,12 +11,6 @@
 
 var objectToString = Object.prototype.toString;
 
-// Determines whether the specified object is a function.
-var functionObjectIdentifier = objectToString.call(function() {});
-var isFunction = function(obj) {
-  return obj && objectToString.call(obj) === functionObjectIdentifier;
-};
-
 // Check if input is a buffer. If not, turn it into a string and then
 // encode the bits of its UTF-8 representation into a new Buffer.
 var toBuffer = function(input) {
@@ -53,13 +47,12 @@ var extend = function() {
 var applyCallback = function(status, cb, message, context) {
   if (cb && cb.isPubControlClientCallbackHandler) {
     cb.pubControlClientCallbackHandler(status, message, context);
-  } else if (isFunction(cb)) {
+  } else if (typeof cb === "function") {
     cb(status, message, context);
   }
 };
 
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
-exports.isFunction = isFunction;
 exports.toBuffer = toBuffer;
 exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -17,12 +17,6 @@ var isFunction = function(obj) {
   return obj && objectToString.call(obj) === functionObjectIdentifier;
 };
 
-// Determines whether the specified object is an array.
-var arrayObjectIdentifier = objectToString.call([]);
-var isArray = function(obj) {
-  return obj && objectToString.call(obj) === arrayObjectIdentifier;
-};
-
 // Check if input is a buffer. If not, turn it into a string and then
 // encode the bits of its UTF-8 representation into a new Buffer.
 var toBuffer = function(input) {
@@ -67,6 +61,5 @@ var applyCallback = function(status, cb, message, context) {
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
 exports.isFunction = isFunction;
-exports.isArray = isArray;
 exports.toBuffer = toBuffer;
 exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -83,10 +83,6 @@ var extendClass = function(prototype) {
   }
   return constructor;
 };
-var defineClass = function() {
-  var args = [null].concat(Array.prototype.slice.call(arguments));
-  return extendClass.apply(this, args);
-};
 
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
@@ -107,4 +103,3 @@ exports.isArray = isArray;
 exports.toBuffer = toBuffer;
 exports.extend = extend;
 exports.extendClass = extendClass;
-exports.defineClass = defineClass;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -51,38 +51,6 @@ var extend = function() {
 
   return obj;
 };
-var extendClass = function(prototype) {
-  var constructor, properties;
-  var argc = arguments.length;
-  if (argc >= 3) {
-    constructor = arguments[1];
-    properties = arguments[2];
-  } else if (argc == 2) {
-    var arg = arguments[1];
-    if (isFunction(arg)) {
-      constructor = arg;
-      properties = null;
-    } else {
-      constructor = function() {};
-      properties = arg;
-    }
-  } else if (argc == 1) {
-    constructor = function() {};
-    properties = null;
-  }
-
-  if (isFunction(prototype)) {
-    prototype = new prototype();
-  }
-
-  if (prototype) {
-    constructor.prototype = prototype;
-  }
-  if (properties) {
-    extend(constructor.prototype, properties);
-  }
-  return constructor;
-};
 
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
@@ -102,4 +70,3 @@ exports.isFunction = isFunction;
 exports.isArray = isArray;
 exports.toBuffer = toBuffer;
 exports.extend = extend;
-exports.extendClass = extendClass;

--- a/tests/auth_tests.js
+++ b/tests/auth_tests.js
@@ -13,7 +13,7 @@ var auth = require('../lib/auth');
     assert.equal(authBasic.user, 'user');
     assert.equal(authBasic.pass, 'pass');
     assert.equal(authBasic.buildHeader(), 'Basic ' +
-            new Buffer('user:pass').toString('base64'));
+            Buffer.from('user:pass').toString('base64'));
 })();
 
 (function testAuthJwt() {

--- a/tests/pubcontrolclient_tests.js
+++ b/tests/pubcontrolclient_tests.js
@@ -47,7 +47,7 @@ TestFormat.prototype.export = function() { return {'body': this.body}; };
             items, cb) {
         assert.equal(uri, 'uri');
         assert.equal(authHeader, 'Basic ' +
-                new Buffer('user:pass').toString('base64'));
+                Buffer.from('user:pass').toString('base64'));
         assert.equal(JSON.stringify(items), JSON.stringify([exportedItem]));
         assert.equal(cb, 'callback');
         wasWorkerCalled = true;

--- a/tests/pubcontrolclient_tests.js
+++ b/tests/pubcontrolclient_tests.js
@@ -81,7 +81,7 @@ TestFormat.prototype.export = function() { return {'body': this.body}; };
     var wasPerformHttpRequestCalled = false;
     pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
         assert.equal(reqParams.body, JSON.stringify({'items': 'items'}));
-        assert(utilities.isFunction(cb));
+        assert.equal(typeof cb, "function")
         assert.equal(reqParams.method, 'POST');
         assert.equal(reqParams.headers['Content-Type'], 'application/json');
         assert.equal(reqParams.headers['Content-Length'],
@@ -100,7 +100,7 @@ TestFormat.prototype.export = function() { return {'body': this.body}; };
     var wasPerformHttpRequestCalled = false;
     pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
         assert.equal(reqParams.body, JSON.stringify({'items': 'items'}));
-        assert(utilities.isFunction(cb));
+        assert.equal(typeof cb, "function")
         assert.equal(reqParams.method, 'POST');
         assert.equal(reqParams.headers['Content-Type'], 'application/json');
         assert.equal(reqParams.headers['Content-Length'],

--- a/tests/utilities_tests.js
+++ b/tests/utilities_tests.js
@@ -3,11 +3,6 @@ var assert = require('assert');
 var utilities = require('../lib/utilities');
 var pcccbHandler = require('../lib/pcccbhandler');
 
-(function testIsFunction() {
-    assert(!(utilities.isFunction('hello')));
-    assert(utilities.isFunction(function(){}));
-})();
-
 (function testToBuffer() {
     var buf = new Buffer('hello');
     assert.equal(buf, utilities.toBuffer(buf));

--- a/tests/utilities_tests.js
+++ b/tests/utilities_tests.js
@@ -8,11 +8,6 @@ var pcccbHandler = require('../lib/pcccbhandler');
     assert(utilities.isFunction(function(){}));
 })();
 
-(function testIsArray() {
-    assert(!(utilities.isArray('hello')));
-    assert(utilities.isArray([]));
-})();
-
 (function testToBuffer() {
     var buf = new Buffer('hello');
     assert.equal(buf, utilities.toBuffer(buf));

--- a/tests/utilities_tests.js
+++ b/tests/utilities_tests.js
@@ -3,14 +3,6 @@ var assert = require('assert');
 var utilities = require('../lib/utilities');
 var pcccbHandler = require('../lib/pcccbhandler');
 
-(function testToBuffer() {
-    var buf = new Buffer('hello');
-    assert.equal(buf, utilities.toBuffer(buf));
-    buf = utilities.toBuffer('hello');
-    assert(Buffer.isBuffer(buf));
-    assert(buf.toString(), 'hello');
-})();
-
 (function testApplyCallback() {
     var wasCallbackCalled = false;
     utilities.applyCallback('status', function(status, message,


### PR DESCRIPTION
* [x] No use of `utilities.extendClass`
* [x] Convert `utilities.defineClass` invocations to `class` expressions
  * [x] PubControlClient
  * [x]
    > bengo@LAPTOP-9VBP4TSS:~/dev/fanout/node-pubcontrol$ git grep defineClass
lib/auth.js:var AuthBase = utilities.defineClass({
lib/format.js:var Format = utilities.defineClass({
lib/item.js:var Item = utilities.defineClass(
lib/pcccbhandler.js:var PubControlClientCallbackHandler = utilities.defineClass(
lib/pubcontrol.js:var PubControl = utilities.defineClass(
lib/utilities.js:var defineClass = function() {
lib/utilities.js:exports.defineClass = defineClass;
* [x] remove many unnecessary utilities.js
* [x] remove unsafe use of `new Buffer()`