### PR TITLE
Eslint after modernize

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,7 @@
 module.exports = {
   extends: ["plugin:prettier/recommended"],
   parserOptions: {
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true
-    },
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: "module"
   }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "10"
   - "9"
   - "8"
-  - "7"
 script:
   - npm test
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,8 @@ node_js:
   - "9"
   - "8"
   - "7"
-
-jobs:
-  include:
-    - stage: test
-      script:
-        - make
-    - stage: test
-      script:
-        - (cd etc/browser-demo && make)
-    - stage: test
-      script: npm run lint
+script:
+  - npm test
+  - npm run lint
+  - make
+  - (cd etc/browser-demo && make)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ jobs:
     - stage: test
       script:
         - (cd etc/browser-demo && make)
+    - stage: test
+      script: npm run lint

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var callback = function(success, message, context) {
 var pub = new pubcontrol.PubControl({
         'uri': 'https://api.fanout.io/realm/<myrealm>',
         'iss': '<myrealm>',
-        'key': new Buffer('<myrealmkey', 'base64')});
+        'key': Buffer.from('<myrealmkey', 'base64')});
 
 // Add new endpoints by applying an endpoint configuration:
 pub.applyConfig([{'uri': '<myendpoint_uri_1>'},

--- a/etc/browser-demo/src/test.js
+++ b/etc/browser-demo/src/test.js
@@ -4,7 +4,7 @@ import { inherits } from "util";
 const defaultOpts = {
   uri: "http://api.webhookinbox.com/i/K1BiRnDW/in/",
   iss: "testPubControl defaultOpts Issuer",
-  key: new Buffer("testPubControl defaultOpts realmKey", "base64"),
+  key: Buffer.from("testPubControl defaultOpts realmKey", "base64"),
   defaultChannel: "testPubcontrol defaultOpts defaultChannel"
 };
 
@@ -20,7 +20,7 @@ async function testFromReadme({ uri, iss, key, defaultChannel }) {
   // const pub = new PubControl({
   //   'uri': 'https://api.fanout.io/realm/<myrealm>',
   //   'iss': '<myrealm>',
-  //   'key': new Buffer('<myrealmkey', 'base64')
+  //   'key': Buffer.from('<myrealmkey', 'base64')
   // });
   const pub = new PubControl({ uri, iss, key });
   // var pubclient = new PubControlClient('<myendpoint_uri>');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -51,7 +51,7 @@ class AuthJwt extends AuthBase {
       this.key = null;
     } else {
       this.claim = claim;
-      this.key = utilities.toBuffer(key);
+      this.key = key instanceof Buffer ? key : Buffer.from(String(key), "utf8");
       this.token = null;
     }
   }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -61,14 +61,12 @@ class AuthJwt extends AuthBase {
     if (this.token != null) {
       token = this.token;
     } else {
-      var claim;
-      if (!("exp" in this.claim)) {
-        claim = utilities.extend({}, this.claim, {
-          exp: Math.floor(new Date().getTime() / 1000) + 600
-        });
-      } else {
-        claim = this.claim;
-      }
+      const claim =
+        "exp" in this.claim
+          ? this.claim
+          : Object.assign({}, this.claim, {
+              exp: Math.floor(new Date().getTime() / 1000) + 600
+            });
       token = jwt.encode(claim, this.key);
     }
     return "Bearer " + token;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -33,7 +33,7 @@ class AuthBasic extends AuthBase {
   // in Basic auth format.
   buildHeader() {
     var data = this.user + ":" + this.pass;
-    return "Basic " + new Buffer(data).toString("base64");
+    return "Basic " + Buffer.from(data).toString("base64");
   }
 }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,38 +15,34 @@ var utilities = require("./utilities");
 
 // The authorization base class for building auth headers in conjunction
 // with HTTP requests used for publishing messages.
-var AuthBase = utilities.defineClass({
+class AuthBase {
   // This method should return the auth header in text format.
-  buildHeader: function() {
+  buildHeader() {
     return null;
   }
-});
+}
 
-// The basic authentication class used for building auth headers containing
-// a username and password.
-var AuthBasic = utilities.extendClass(
-  AuthBase,
-  function(user, pass) {
+class AuthBasic extends AuthBase {
+  constructor(user, pass) {
+    super();
     // Initialize with a username and password.
     this.user = user;
     this.pass = pass;
-  },
-  {
-    // Returns the auth header containing the username and password
-    // in Basic auth format.
-    buildHeader: function() {
-      var data = this.user + ":" + this.pass;
-      return "Basic " + new Buffer(data).toString("base64");
-    }
   }
-);
+  // Returns the auth header containing the username and password
+  // in Basic auth format.
+  buildHeader() {
+    var data = this.user + ":" + this.pass;
+    return "Basic " + new Buffer(data).toString("base64");
+  }
+}
 
 // JWT authentication class used for building auth headers containing
 // JSON web token information in either the form of a claim and
 // corresponding key, or the literal token itself.
-var AuthJwt = utilities.extendClass(
-  AuthBase,
-  function(claim, key) {
+class AuthJwt extends AuthBase {
+  constructor(claim, key) {
+    super();
     // Initialize with the specified claim and key. If only one parameter
     // was provided then treat it as the literal token.
     if (arguments.length == 1) {
@@ -58,28 +54,26 @@ var AuthJwt = utilities.extendClass(
       this.key = utilities.toBuffer(key);
       this.token = null;
     }
-  },
-  {
-    // Returns the auth header containing the JWT token in Bearer format.
-    buildHeader: function() {
-      var token;
-      if (this.token != null) {
-        token = this.token;
-      } else {
-        var claim;
-        if (!("exp" in this.claim)) {
-          claim = utilities.extend({}, this.claim, {
-            exp: Math.floor(new Date().getTime() / 1000) + 600
-          });
-        } else {
-          claim = this.claim;
-        }
-        token = jwt.encode(claim, this.key);
-      }
-      return "Bearer " + token;
-    }
   }
-);
+  // Returns the auth header containing the JWT token in Bearer format.
+  buildHeader() {
+    var token;
+    if (this.token != null) {
+      token = this.token;
+    } else {
+      var claim;
+      if (!("exp" in this.claim)) {
+        claim = utilities.extend({}, this.claim, {
+          exp: Math.floor(new Date().getTime() / 1000) + 600
+        });
+      } else {
+        claim = this.claim;
+      }
+      token = jwt.encode(claim, this.key);
+    }
+    return "Bearer " + token;
+  }
+}
 
 exports.AuthBase = AuthBase;
 exports.AuthBasic = AuthBasic;

--- a/lib/format.js
+++ b/lib/format.js
@@ -14,18 +14,17 @@ var utilities = require("./utilities");
 // The Format class is provided as a base class for all publishing
 // formats that are included in the Item class. Examples of format
 // implementations include JsonObjectFormat and HttpStreamFormat.
-var Format = utilities.defineClass({
+class Format {
   // The name of the format which should return a string. Examples
   // include 'json-object' and 'http-response'
-  name: function() {
-    return null;
-  },
-
-  // The export method which should return a format-specific hash
-  // containing the required format-specific data.
-  export: function() {
+  name() {
     return null;
   }
-});
+  // The export method which should return a format-specific hash
+  // containing the required format-specific data.
+  export() {
+    return null;
+  }
+}
 
 exports.Format = Format;

--- a/lib/item.js
+++ b/lib/item.js
@@ -22,7 +22,7 @@ class Item {
     // instance or an array of Format implementation instances. Optionally
     // specify an ID and/or previous ID to be sent as part of the message
     // published to the client.
-    var formats = utilities.isArray(formats) ? formats : [formats];
+    var formats = Array.isArray(formats) ? formats : [formats];
     this.formats = formats;
     if (arguments.length >= 3) {
       this.prevId = prevId;

--- a/lib/item.js
+++ b/lib/item.js
@@ -16,8 +16,8 @@ var utilities = require("./utilities");
 // different type of format. An Item instance may not contain multiple
 // implementations of the same type of format. An Item instance is then
 // serialized into a hash that is used for publishing to clients.
-var Item = utilities.defineClass(
-  function(formats, id, prevId) {
+class Item {
+  constructor(formats, id, prevId) {
     // The initialize method can accept either a single Format implementation
     // instance or an array of Format implementation instances. Optionally
     // specify an ID and/or previous ID to be sent as part of the message
@@ -30,36 +30,34 @@ var Item = utilities.defineClass(
     if (arguments.length >= 2) {
       this.id = id;
     }
-  },
-  {
-    // The export method serializes all of the formats, ID, and previous ID
-    // into a hash that is used for publishing to clients. If more than one
-    // instance of the same type of Format implementation was specified then
-    // an error will be raised.
-    export: function() {
-      var formatNames = [];
-      this.formats.forEach(function(format) {
-        var formatName = format.name();
-        if (formatNames.indexOf(formatName) >= 0) {
-          throw new Error(
-            "More than one instance of " + formatName + " specified"
-          );
-        }
-        formatNames.push(formatName);
-      });
-      var obj = {};
-      if ("id" in this) {
-        obj["id"] = this.id;
-      }
-      if ("prevId" in this) {
-        obj["prev-id"] = this.prevId;
-      }
-      this.formats.forEach(function(format) {
-        obj[format.name()] = format.export();
-      });
-      return obj;
-    }
   }
-);
+  // The export method serializes all of the formats, ID, and previous ID
+  // into a hash that is used for publishing to clients. If more than one
+  // instance of the same type of Format implementation was specified then
+  // an error will be raised.
+  export() {
+    var formatNames = [];
+    this.formats.forEach(function(format) {
+      var formatName = format.name();
+      if (formatNames.indexOf(formatName) >= 0) {
+        throw new Error(
+          "More than one instance of " + formatName + " specified"
+        );
+      }
+      formatNames.push(formatName);
+    });
+    var obj = {};
+    if ("id" in this) {
+      obj["id"] = this.id;
+    }
+    if ("prevId" in this) {
+      obj["prev-id"] = this.prevId;
+    }
+    this.formats.forEach(function(format) {
+      obj[format.name()] = format.export();
+    });
+    return obj;
+  }
+}
 
 exports.Item = Item;

--- a/lib/pcccbhandler.js
+++ b/lib/pcccbhandler.js
@@ -19,8 +19,8 @@ var utilities = require("./utilities");
 // instances. A failure to publish in any of the PubControlClient instances
 // will result in a failed result passed to the callback method and the error
 // from the first encountered failure.
-var PubControlClientCallbackHandler = utilities.defineClass(
-  function(numCalls, callback) {
+class PubControlClientCallbackHandler {
+  constructor(numCalls, callback) {
     // The initialize method accepts: a num_calls parameter which is an integer
     // representing the number of PubControlClient instances, and a callback
     // method to be executed after all publishing is complete.
@@ -29,37 +29,34 @@ var PubControlClientCallbackHandler = utilities.defineClass(
     this.success = true;
     this.firstErrorMessage = null;
     this.firstErrorContext = null;
-  },
-  {
-    // Helper method for determining whether the object is an instance
-    // of PubControlClientCallbackHandler.
-    isPubControlClientCallbackHandler: function() {
-      return true;
-    },
-
-    // The handler method which is executed by PubControlClient when publishing
-    // is complete. This method tracks the number of publishes performed and
-    // when all publishes are complete it will call the callback method
-    // originally specified by the consumer. If publishing failures are
-    // encountered only the first error is saved and reported to the callback
-    // method.
-    pubControlClientCallbackHandler: function(success, message, context) {
-      if (!success && this.success) {
-        this.success = false;
-        this.firstErrorMessage = message;
-        this.firstErrorContext = context;
-      }
-      this.numCalls -= 1;
-      if (this.numCalls <= 0) {
-        utilities.applyCallback(
-          this.success,
-          this.callback,
-          this.firstErrorMessage,
-          this.firstErrorContext
-        );
-      }
+  }
+  // Helper method for determining whether the object is an instance
+  // of PubControlClientCallbackHandler.
+  isPubControlClientCallbackHandler() {
+    return true;
+  }
+  // The handler method which is executed by PubControlClient when publishing
+  // is complete. This method tracks the number of publishes performed and
+  // when all publishes are complete it will call the callback method
+  // originally specified by the consumer. If publishing failures are
+  // encountered only the first error is saved and reported to the callback
+  // method.
+  pubControlClientCallbackHandler(success, message, context) {
+    if (!success && this.success) {
+      this.success = false;
+      this.firstErrorMessage = message;
+      this.firstErrorContext = context;
+    }
+    this.numCalls -= 1;
+    if (this.numCalls <= 0) {
+      utilities.applyCallback(
+        this.success,
+        this.callback,
+        this.firstErrorMessage,
+        this.firstErrorContext
+      );
     }
   }
-);
+}
 
 exports.PubControlClientCallbackHandler = PubControlClientCallbackHandler;

--- a/lib/pubcontrol.js
+++ b/lib/pubcontrol.js
@@ -19,8 +19,8 @@ var pubControlClient = require("./pubcontrolclient");
 // method call. A PubControl instance can be configured either using a
 // hash or array of hashes containing configuration information or by
 // manually adding PubControlClient instances.
-var PubControl = utilities.defineClass(
-  function(config) {
+class PubControl {
+  constructor(config) {
     // Initialize with or without a configuration. A configuration can be applied
     // after initialization via the apply_config method.
     if (arguments.length == 1) {
@@ -28,61 +28,57 @@ var PubControl = utilities.defineClass(
     } else {
       this.clients = [];
     }
-  },
-  {
-    // Remove all of the configured PubControlClient instances.
-    removeAllClients: function() {
-      this.clients = [];
-    },
-
-    // Add the specified PubControlClient instance.
-    addClient: function(client) {
-      this.clients.push(client);
-    },
-
-    // Apply the specified configuration to this PubControl instance. The
-    // configuration object can either be a hash or an array of hashes where
-    // each hash corresponds to a single PubControlClient instance. Each hash
-    // will be parsed and a PubControlClient will be created either using just
-    // a URI or a URI and JWT authentication information.
-    applyConfig: function(config) {
-      var clients = [];
-      if (typeof this.clients !== "undefined") {
-        clients = this.clients;
-      }
-      var config = utilities.isArray(config) ? config : [config];
-      config.forEach(function(entry) {
-        var client = new pubControlClient.PubControlClient(entry["uri"]);
-        if ("iss" in entry) {
-          client.setAuthJwt({ iss: entry["iss"] }, entry["key"]);
-        }
-        clients.push(client);
-      });
-      this.clients = clients;
-    },
-
-    // The publish method for publishing the specified item to the specified
-    // channel on the configured endpoint. The callback method is optional
-    // and will be passed the publishing results after publishing is complete.
-    // Note that a failure to publish in any of the configured PubControlClient
-    // instances will result in a failure result being passed to the callback
-    // method along with the first encountered error message.
-    publish: function(channel, item, cb) {
-      // TODO: Figure out how to pass the callback itself while avoiding
-      // the pcccbhandler instance issue.
-      var pcccbhandler = null;
-      if (utilities.isFunction(cb)) {
-        pcccbhandler = new pcccbHandler.PubControlClientCallbackHandler(
-          this.clients.length,
-          cb
-        );
-      }
-      this.clients.forEach(function(client) {
-        client.publish(channel, item, pcccbhandler);
-      });
-    }
   }
-);
+  // Remove all of the configured PubControlClient instances.
+  removeAllClients() {
+    this.clients = [];
+  }
+  // Add the specified PubControlClient instance.
+  addClient(client) {
+    this.clients.push(client);
+  }
+  // Apply the specified configuration to this PubControl instance. The
+  // configuration object can either be a hash or an array of hashes where
+  // each hash corresponds to a single PubControlClient instance. Each hash
+  // will be parsed and a PubControlClient will be created either using just
+  // a URI or a URI and JWT authentication information.
+  applyConfig(config) {
+    var clients = [];
+    if (typeof this.clients !== "undefined") {
+      clients = this.clients;
+    }
+    var config = utilities.isArray(config) ? config : [config];
+    config.forEach(function(entry) {
+      var client = new pubControlClient.PubControlClient(entry["uri"]);
+      if ("iss" in entry) {
+        client.setAuthJwt({ iss: entry["iss"] }, entry["key"]);
+      }
+      clients.push(client);
+    });
+    this.clients = clients;
+  }
+
+  // The publish method for publishing the specified item to the specified
+  // channel on the configured endpoint. The callback method is optional
+  // and will be passed the publishing results after publishing is complete.
+  // Note that a failure to publish in any of the configured PubControlClient
+  // instances will result in a failure result being passed to the callback
+  // method along with the first encountered error message.
+  publish(channel, item, cb) {
+    // TODO: Figure out how to pass the callback itself while avoiding
+    // the pcccbhandler instance issue.
+    var pcccbhandler = null;
+    if (utilities.isFunction(cb)) {
+      pcccbhandler = new pcccbHandler.PubControlClientCallbackHandler(
+        this.clients.length,
+        cb
+      );
+    }
+    this.clients.forEach(function(client) {
+      client.publish(channel, item, pcccbhandler);
+    });
+  }
+}
 
 exports.Format = format.Format;
 exports.Item = item.Item;

--- a/lib/pubcontrol.js
+++ b/lib/pubcontrol.js
@@ -68,7 +68,7 @@ class PubControl {
     // TODO: Figure out how to pass the callback itself while avoiding
     // the pcccbhandler instance issue.
     var pcccbhandler = null;
-    if (utilities.isFunction(cb)) {
+    if (typeof cb === "function") {
       pcccbhandler = new pcccbHandler.PubControlClientCallbackHandler(
         this.clients.length,
         cb

--- a/lib/pubcontrol.js
+++ b/lib/pubcontrol.js
@@ -47,7 +47,7 @@ class PubControl {
     if (typeof this.clients !== "undefined") {
       clients = this.clients;
     }
-    var config = utilities.isArray(config) ? config : [config];
+    var config = Array.isArray(config) ? config : [config];
     config.forEach(function(entry) {
       var client = new pubControlClient.PubControlClient(entry["uri"]);
       if ("iss" in entry) {

--- a/lib/pubcontrolclient.js
+++ b/lib/pubcontrolclient.js
@@ -22,124 +22,115 @@ var auth = require("./auth");
 // instance and passes that to the publish method. The publish method has
 // an optional callback parameter that is called after the publishing is
 // complete to notify the consumer of the result.
-var PubControlClient = utilities.defineClass(
-  function(uri) {
+exports.PubControlClient = class PubControlClientModern {
+  constructor(uri) {
     // Initialize this class with a URL representing the publishing endpoint.
     this.uri = uri.replace(/\/$/, "");
     this.auth = null;
     this.httpKeepAliveAgent = new agentkeepalive();
     this.httpsKeepAliveAgent = new agentkeepalive.HttpsAgent();
-  },
-  {
-    // Call this method and pass a username and password to use basic
-    // authentication with the configured endpoint.
-    setAuthBasic: function(username, password) {
-      this.auth = new auth.AuthBasic(username, password);
-    },
-
-    // Call this method and pass a claim and key to use JWT authentication
-    // with the configured endpoint.
-    setAuthJwt: function(claim, key) {
-      if (key) {
-        this.auth = new auth.AuthJwt(claim, key);
-      } else {
-        this.auth = new auth.AuthJwt(claim);
-      }
-    },
-
-    // The publish method for publishing the specified item to the specified
-    // channel on the configured endpoint. The callback method is optional
-    // and will be passed the publishing results after publishing is complete.
-    publish: function(channel, item, cb) {
-      var i = item.export();
-      i["channel"] = channel;
-      var authHeader = this.auth != null ? this.auth.buildHeader() : null;
-      this.startPubCall(this.uri, authHeader, [i], cb);
-    },
-
-    // An internal method for starting the work required for publishing
-    // a message. Accepts the URI endpoint, authorization header, items
-    // object, and optional callback as parameters.
-    startPubCall: function(uri, authHeader, items, cb) {
-      // Prepare Request Body
-      var content = JSON.stringify({ items: items });
-      // Build HTTP headers
-      var headers = {
-        "Content-Type": "application/json",
-        "Content-Length": Buffer.byteLength(content, "utf8")
-      };
-      if (authHeader != null) {
-        headers["Authorization"] = authHeader;
-      }
-      // Build HTTP request parameters
-      var publishUri = uri + "/publish/";
-      var parsed = url.parse(publishUri);
-      var reqParams = {
-        method: "POST",
-        headers: headers,
-        body: content
-      };
-      switch (parsed.protocol) {
-        case "http:":
-          reqParams.agent = this.httpKeepAliveAgent;
-          break;
-        case "https:":
-          reqParams.agent = this.httpsKeepAliveAgent;
-          break;
-        default:
-          setTimeout(function() {
-            utilities.applyCallback(false, cb, "Bad URI", {
-              statusCode: -2
-            });
-          }, 0);
-          return;
-      }
-      this.performHttpRequest(cb, fetch, publishUri, reqParams);
-    },
-
-    // An internal method for performing the HTTP request for publishing
-    // a message with the specified parameters.
-    performHttpRequest: function(cb, transport, uri, reqParams) {
-      var finishHttpRequest = this.finishHttpRequest;
-      transport(uri, reqParams).then(
-        function(res) {
-          var context = {
-            statusCode: res.status,
-            headers: res.headers
-          };
-          res.text().then(
-            function(data) {
-              finishHttpRequest("end", cb, data, context);
-            },
-            function(err) {
-              finishHttpRequest("close", cb, err, context);
-            }
-          );
-        },
-        function(err) {
-          utilities.applyCallback(false, cb, err.message, {
-            statusCode: -1
-          });
-        }
-      );
-    },
-
-    // An internal method for finishing the HTTP request for publishing
-    // a message.
-    finishHttpRequest: function(mode, cb, httpData, context) {
-      context.httpBody = httpData;
-      var success;
-      var message;
-      if (mode === "end") {
-        success = context.statusCode >= 200 && context.statusCode < 300;
-        message = success ? "" : JSON.stringify(context.httpBody);
-      } else if (mode === "close") {
-        success = false;
-        message = "Connection closed unexpectedly";
-      }
-      utilities.applyCallback(success, cb, message, context);
+  }
+  // Call this method and pass a username and password to use basic
+  // authentication with the configured endpoint.
+  setAuthBasic(username, password) {
+    this.auth = new auth.AuthBasic(username, password);
+  }
+  // Call this method and pass a claim and key to use JWT authentication
+  // with the configured endpoint.
+  setAuthJwt(claim, key) {
+    if (key) {
+      this.auth = new auth.AuthJwt(claim, key);
+    } else {
+      this.auth = new auth.AuthJwt(claim);
     }
   }
-);
-
-exports.PubControlClient = PubControlClient;
+  // The publish method for publishing the specified item to the specified
+  // channel on the configured endpoint. The callback method is optional
+  // and will be passed the publishing results after publishing is complete.
+  publish(channel, item, cb) {
+    var i = item.export();
+    i["channel"] = channel;
+    var authHeader = this.auth != null ? this.auth.buildHeader() : null;
+    this.startPubCall(this.uri, authHeader, [i], cb);
+  }
+  // An internal method for starting the work required for publishing
+  // a message. Accepts the URI endpoint, authorization header, items
+  // object, and optional callback as parameters.
+  startPubCall(uri, authHeader, items, cb) {
+    // Prepare Request Body
+    var content = JSON.stringify({ items: items });
+    // Build HTTP headers
+    var headers = {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(content, "utf8")
+    };
+    if (authHeader != null) {
+      headers["Authorization"] = authHeader;
+    }
+    // Build HTTP request parameters
+    var publishUri = uri + "/publish/";
+    var parsed = url.parse(publishUri);
+    var reqParams = {
+      method: "POST",
+      headers: headers,
+      body: content
+    };
+    switch (parsed.protocol) {
+      case "http:":
+        reqParams.agent = this.httpKeepAliveAgent;
+        break;
+      case "https:":
+        reqParams.agent = this.httpsKeepAliveAgent;
+        break;
+      default:
+        setTimeout(function() {
+          utilities.applyCallback(false, cb, "Bad URI", {
+            statusCode: -2
+          });
+        }, 0);
+        return;
+    }
+    this.performHttpRequest(cb, fetch, publishUri, reqParams);
+  }
+  // An internal method for performing the HTTP request for publishing
+  // a message with the specified parameters.
+  performHttpRequest(cb, transport, uri, reqParams) {
+    var finishHttpRequest = this.finishHttpRequest;
+    transport(uri, reqParams).then(
+      function(res) {
+        var context = {
+          statusCode: res.status,
+          headers: res.headers
+        };
+        res.text().then(
+          function(data) {
+            finishHttpRequest("end", cb, data, context);
+          },
+          function(err) {
+            finishHttpRequest("close", cb, err, context);
+          }
+        );
+      },
+      function(err) {
+        utilities.applyCallback(false, cb, err.message, {
+          statusCode: -1
+        });
+      }
+    );
+  }
+  // An internal method for finishing the HTTP request for publishing
+  // a message.
+  finishHttpRequest(mode, cb, httpData, context) {
+    context.httpBody = httpData;
+    var success;
+    var message;
+    if (mode === "end") {
+      success = context.statusCode >= 200 && context.statusCode < 300;
+      message = success ? "" : JSON.stringify(context.httpBody);
+    } else if (mode === "close") {
+      success = false;
+      message = "Connection closed unexpectedly";
+    }
+    utilities.applyCallback(success, cb, message, context);
+  }
+};

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -11,29 +11,6 @@
 
 var objectToString = Object.prototype.toString;
 
-// Class creation and management methods.
-var extend = function() {
-  var args = Array.prototype.slice.call(arguments);
-
-  var obj;
-  if (args.length > 1) {
-    obj = args.shift();
-  } else {
-    obj = {};
-  }
-
-  while (args.length > 0) {
-    var opts = args.shift();
-    if (opts != null) {
-      for (prop in opts) {
-        obj[prop] = opts[prop];
-      }
-    }
-  }
-
-  return obj;
-};
-
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
 // callback is executed depends on whether the callback object
@@ -48,4 +25,3 @@ var applyCallback = function(status, cb, message, context) {
 
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
-exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -11,12 +11,6 @@
 
 var objectToString = Object.prototype.toString;
 
-// Check if input is a buffer. If not, turn it into a string and then
-// encode the bits of its UTF-8 representation into a new Buffer.
-var toBuffer = function(input) {
-  return Buffer.isBuffer(input) ? input : new Buffer(input.toString(), "utf8");
-};
-
 // Class creation and management methods.
 var extend = function() {
   var args = Array.prototype.slice.call(arguments);
@@ -54,5 +48,4 @@ var applyCallback = function(status, cb, message, context) {
 
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
-exports.toBuffer = toBuffer;
 exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -9,8 +9,6 @@
  * Licensed under the MIT License, see file COPYING for details.
  */
 
-var objectToString = Object.prototype.toString;
-
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
 // callback is executed depends on whether the callback object
@@ -24,4 +22,3 @@ var applyCallback = function(status, cb, message, context) {
 };
 
 exports.applyCallback = applyCallback;
-exports.objectToString = objectToString;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -11,12 +11,6 @@
 
 var objectToString = Object.prototype.toString;
 
-// Determines whether the specified object is a function.
-var functionObjectIdentifier = objectToString.call(function() {});
-var isFunction = function(obj) {
-  return obj && objectToString.call(obj) === functionObjectIdentifier;
-};
-
 // Check if input is a buffer. If not, turn it into a string and then
 // encode the bits of its UTF-8 representation into a new Buffer.
 var toBuffer = function(input) {
@@ -53,13 +47,12 @@ var extend = function() {
 var applyCallback = function(status, cb, message, context) {
   if (cb && cb.isPubControlClientCallbackHandler) {
     cb.pubControlClientCallbackHandler(status, message, context);
-  } else if (isFunction(cb)) {
+  } else if (typeof cb === "function") {
     cb(status, message, context);
   }
 };
 
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
-exports.isFunction = isFunction;
 exports.toBuffer = toBuffer;
 exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -17,12 +17,6 @@ var isFunction = function(obj) {
   return obj && objectToString.call(obj) === functionObjectIdentifier;
 };
 
-// Determines whether the specified object is an array.
-var arrayObjectIdentifier = objectToString.call([]);
-var isArray = function(obj) {
-  return obj && objectToString.call(obj) === arrayObjectIdentifier;
-};
-
 // Check if input is a buffer. If not, turn it into a string and then
 // encode the bits of its UTF-8 representation into a new Buffer.
 var toBuffer = function(input) {
@@ -67,6 +61,5 @@ var applyCallback = function(status, cb, message, context) {
 exports.applyCallback = applyCallback;
 exports.objectToString = objectToString;
 exports.isFunction = isFunction;
-exports.isArray = isArray;
 exports.toBuffer = toBuffer;
 exports.extend = extend;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -83,10 +83,6 @@ var extendClass = function(prototype) {
   }
   return constructor;
 };
-var defineClass = function() {
-  var args = [null].concat(Array.prototype.slice.call(arguments));
-  return extendClass.apply(this, args);
-};
 
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
@@ -107,4 +103,3 @@ exports.isArray = isArray;
 exports.toBuffer = toBuffer;
 exports.extend = extend;
 exports.extendClass = extendClass;
-exports.defineClass = defineClass;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -51,38 +51,6 @@ var extend = function() {
 
   return obj;
 };
-var extendClass = function(prototype) {
-  var constructor, properties;
-  var argc = arguments.length;
-  if (argc >= 3) {
-    constructor = arguments[1];
-    properties = arguments[2];
-  } else if (argc == 2) {
-    var arg = arguments[1];
-    if (isFunction(arg)) {
-      constructor = arg;
-      properties = null;
-    } else {
-      constructor = function() {};
-      properties = arg;
-    }
-  } else if (argc == 1) {
-    constructor = function() {};
-    properties = null;
-  }
-
-  if (isFunction(prototype)) {
-    prototype = new prototype();
-  }
-
-  if (prototype) {
-    constructor.prototype = prototype;
-  }
-  if (properties) {
-    extend(constructor.prototype, properties);
-  }
-  return constructor;
-};
 
 // Method used for executing a callback method for the specified
 // callback object, status, message, and context. The way the
@@ -102,4 +70,3 @@ exports.isFunction = isFunction;
 exports.isArray = isArray;
 exports.toBuffer = toBuffer;
 exports.extend = extend;
-exports.extendClass = extendClass;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build:webpack:analyze-size": "webpack --config etc/webpack/pubcontrol.webpack.js --profile --json | webpack-bundle-size-analyzer",
     "dev": "http-server dist -p 8090",
     "lint": "concurrently 'npm:lint:eslint'",
-    "lint:eslint": "eslint lib/*",
+    "lint:eslint": "eslint lib/* tests/*",
+    "lint:eslint:fix": "eslint --fix lib/* tests/*",
     "make:dist": "npm run build:webpack",
     "prettier": "prettier --write './{lib,src}/**/*.{js,jsx,ts,tsx}' '.eslintrc.js'",
     "test": "./bin/test"

--- a/tests/auth_tests.js
+++ b/tests/auth_tests.js
@@ -1,40 +1,43 @@
 #!/usr/bin/env node
-var assert = require('assert');
-var jwt = require('jwt-simple');
-var auth = require('../lib/auth');
+var assert = require("assert");
+var jwt = require("jwt-simple");
+var auth = require("../lib/auth");
 
 (function testAuthBase() {
-    var authBase = new auth.AuthBase();
-    assert.equal(authBase.buildHeader(), null);
+  var authBase = new auth.AuthBase();
+  assert.equal(authBase.buildHeader(), null);
 })();
 
 (function testAuthBasic() {
-    var authBasic = new auth.AuthBasic('user', 'pass');
-    assert.equal(authBasic.user, 'user');
-    assert.equal(authBasic.pass, 'pass');
-    assert.equal(authBasic.buildHeader(), 'Basic ' +
-            Buffer.from('user:pass').toString('base64'));
+  var authBasic = new auth.AuthBasic("user", "pass");
+  assert.equal(authBasic.user, "user");
+  assert.equal(authBasic.pass, "pass");
+  assert.equal(
+    authBasic.buildHeader(),
+    "Basic " + Buffer.from("user:pass").toString("base64")
+  );
 })();
 
 (function testAuthJwt() {
-    var authJwt = new auth.AuthJwt('claim', 'key');
-    assert.equal(authJwt.claim, 'claim');
-    assert.equal(authJwt.key, 'key');
-    assert(Buffer.isBuffer(authJwt.key));
-    assert.equal(authJwt.token, null);
-    authJwt = new auth.AuthJwt('token');
-    assert.equal(authJwt.claim, null);
-    assert.equal(authJwt.key, null);
-    assert.equal(authJwt.token, 'token');
-    assert.equal(authJwt.buildHeader(), 'Bearer token');
-    authJwt = new auth.AuthJwt({'iss': 'hello', 'exp': 1426106601},
-            'key==');
-    assert.equal(authJwt.buildHeader(), 'Bearer eyJ0eXAiOiJKV1QiLCJhbG' +
-            'ciOiJIUzI1NiJ9.eyJpc3MiOiJoZWxsbyIsImV4cCI6MT' +
-            'QyNjEwNjYwMX0.beCyAv3kUlIYomos527H1HrzKJbgSGewQjYzoAv0XNo');
-    authJwt = new auth.AuthJwt({'iss': 'hello'},
-            'key==');
-    var claim = jwt.decode(authJwt.buildHeader().substring(7), 'key==');
-    assert('exp' in claim);
-    assert.equal(claim['iss'], 'hello');
+  var authJwt = new auth.AuthJwt("claim", "key");
+  assert.equal(authJwt.claim, "claim");
+  assert.equal(authJwt.key, "key");
+  assert(Buffer.isBuffer(authJwt.key));
+  assert.equal(authJwt.token, null);
+  authJwt = new auth.AuthJwt("token");
+  assert.equal(authJwt.claim, null);
+  assert.equal(authJwt.key, null);
+  assert.equal(authJwt.token, "token");
+  assert.equal(authJwt.buildHeader(), "Bearer token");
+  authJwt = new auth.AuthJwt({ iss: "hello", exp: 1426106601 }, "key==");
+  assert.equal(
+    authJwt.buildHeader(),
+    "Bearer eyJ0eXAiOiJKV1QiLCJhbG" +
+      "ciOiJIUzI1NiJ9.eyJpc3MiOiJoZWxsbyIsImV4cCI6MT" +
+      "QyNjEwNjYwMX0.beCyAv3kUlIYomos527H1HrzKJbgSGewQjYzoAv0XNo"
+  );
+  authJwt = new auth.AuthJwt({ iss: "hello" }, "key==");
+  var claim = jwt.decode(authJwt.buildHeader().substring(7), "key==");
+  assert("exp" in claim);
+  assert.equal(claim["iss"], "hello");
 })();

--- a/tests/auth_tests.js
+++ b/tests/auth_tests.js
@@ -13,7 +13,7 @@ var auth = require('../lib/auth');
     assert.equal(authBasic.user, 'user');
     assert.equal(authBasic.pass, 'pass');
     assert.equal(authBasic.buildHeader(), 'Basic ' +
-            new Buffer('user:pass').toString('base64'));
+            Buffer.from('user:pass').toString('base64'));
 })();
 
 (function testAuthJwt() {

--- a/tests/format_tests.js
+++ b/tests/format_tests.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-var assert = require('assert');
-var format = require('../lib/format');
+var assert = require("assert");
+var format = require("../lib/format");
 
 var fmt = new format.Format();
 assert.equal(fmt.name(), null);

--- a/tests/item_tests.js
+++ b/tests/item_tests.js
@@ -1,61 +1,78 @@
 #!/usr/bin/env node
-var assert = require('assert');
-var item = require('../lib/item');
-var format = require('../lib/format');
-var util = require('util');
+var assert = require("assert");
+var item = require("../lib/item");
+var format = require("../lib/format");
+var util = require("util");
 
-var TestFormat1 = function(body) { this.body = body; };
+var TestFormat1 = function(body) {
+  this.body = body;
+};
 util.inherits(TestFormat1, format.Format);
-TestFormat1.prototype.name = function() { return 'testformat1'; };
-TestFormat1.prototype.export = function() { return {'body': this.body}; }
+TestFormat1.prototype.name = function() {
+  return "testformat1";
+};
+TestFormat1.prototype.export = function() {
+  return { body: this.body };
+};
 
-var TestFormat2 = function(body) { this.body = body; };
+var TestFormat2 = function(body) {
+  this.body = body;
+};
 util.inherits(TestFormat2, format.Format);
-TestFormat2.prototype.name = function() { return 'testformat2'; };
-TestFormat2.prototype.export = function() { return {'body': this.body}; }
+TestFormat2.prototype.name = function() {
+  return "testformat2";
+};
+TestFormat2.prototype.export = function() {
+  return { body: this.body };
+};
 
-var fmt1a = new TestFormat1('body1a');
-var fmt1b = new TestFormat1('body1b');
-var fmt2a = new TestFormat2('body2a');
+var fmt1a = new TestFormat1("body1a");
+var fmt1b = new TestFormat1("body1b");
+var fmt2a = new TestFormat2("body2a");
 
 (function testInitialize() {
-    var itm = new item.Item(fmt1a);
-    assert.equal(itm.formats[0], fmt1a);
-    itm = new item.Item(fmt1a, 'id');
-    assert.equal(itm.formats[0], fmt1a);
-    assert.equal(itm.id, 'id');
-    itm = new item.Item(fmt1a, 'id', 'prev-id');
-    assert.equal(itm.formats[0], fmt1a);
-    assert.equal(itm.id, 'id');
-    assert.equal(itm.prevId, 'prev-id');
-    itm = new item.Item([fmt1a, fmt2a]);
-    assert.equal(itm.formats[0], fmt1a);
-    assert.equal(itm.formats[1], fmt2a);
+  var itm = new item.Item(fmt1a);
+  assert.equal(itm.formats[0], fmt1a);
+  itm = new item.Item(fmt1a, "id");
+  assert.equal(itm.formats[0], fmt1a);
+  assert.equal(itm.id, "id");
+  itm = new item.Item(fmt1a, "id", "prev-id");
+  assert.equal(itm.formats[0], fmt1a);
+  assert.equal(itm.id, "id");
+  assert.equal(itm.prevId, "prev-id");
+  itm = new item.Item([fmt1a, fmt2a]);
+  assert.equal(itm.formats[0], fmt1a);
+  assert.equal(itm.formats[1], fmt2a);
 })();
 
 (function testExport() {
-    var itm = new item.Item(fmt1a);
-    assert(!('id' in itm.export()));
-    assert(!('prev-id' in itm.export()));
-    assert.equal(JSON.stringify(itm.export()['testformat1']),
-            JSON.stringify({'body': 'body1a'}));
-    itm = new item.Item([fmt1a, fmt2a]);
-    assert(!('id' in itm.export()));
-    assert(!('prev-id' in itm.export()));
-    assert.equal(JSON.stringify(itm.export()['testformat1']),
-            JSON.stringify({'body': 'body1a'}));
-    assert.equal(JSON.stringify(itm.export()['testformat2']),
-            JSON.stringify({'body': 'body2a'}));
-    assert.throws(
-        function() {
-            itm = new item.Item([fmt1a, fmt1a]);
-            itm.export();
-        },
-        Error
-    );
-    itm = new item.Item(fmt1a, 'id', 'prev-id');
-    assert.equal(itm.export()['id'], 'id');
-    assert.equal(itm.export()['prev-id'], 'prev-id');
-    assert.equal(JSON.stringify(itm.export()['testformat1']),
-            JSON.stringify({'body': 'body1a'}));
+  var itm = new item.Item(fmt1a);
+  assert(!("id" in itm.export()));
+  assert(!("prev-id" in itm.export()));
+  assert.equal(
+    JSON.stringify(itm.export()["testformat1"]),
+    JSON.stringify({ body: "body1a" })
+  );
+  itm = new item.Item([fmt1a, fmt2a]);
+  assert(!("id" in itm.export()));
+  assert(!("prev-id" in itm.export()));
+  assert.equal(
+    JSON.stringify(itm.export()["testformat1"]),
+    JSON.stringify({ body: "body1a" })
+  );
+  assert.equal(
+    JSON.stringify(itm.export()["testformat2"]),
+    JSON.stringify({ body: "body2a" })
+  );
+  assert.throws(function() {
+    itm = new item.Item([fmt1a, fmt1a]);
+    itm.export();
+  }, Error);
+  itm = new item.Item(fmt1a, "id", "prev-id");
+  assert.equal(itm.export()["id"], "id");
+  assert.equal(itm.export()["prev-id"], "prev-id");
+  assert.equal(
+    JSON.stringify(itm.export()["testformat1"]),
+    JSON.stringify({ body: "body1a" })
+  );
 })();

--- a/tests/pcccbhandler_tests.js
+++ b/tests/pcccbhandler_tests.js
@@ -1,77 +1,89 @@
 #!/usr/bin/env node
-var assert = require('assert');
-var pcccbHandler = require('../lib/pcccbhandler');
+var assert = require("assert");
+var pcccbHandler = require("../lib/pcccbhandler");
 
 (function testInitialize() {
-    var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1, 'callback');
-    assert.equal(pcccbh.numCalls, 1);
-    assert.equal(pcccbh.callback, 'callback');
-    assert.equal(pcccbh.success, true);
-    assert.equal(pcccbh.firstErrorMessage, null);
-    assert.equal(pcccbh.firstErrorContext, null);
+  var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1, "callback");
+  assert.equal(pcccbh.numCalls, 1);
+  assert.equal(pcccbh.callback, "callback");
+  assert.equal(pcccbh.success, true);
+  assert.equal(pcccbh.firstErrorMessage, null);
+  assert.equal(pcccbh.firstErrorContext, null);
 })();
 
 (function testIsPubControlClientCallbackHandler() {
-    var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1, 'callback');
-    assert.equal(pcccbh.isPubControlClientCallbackHandler(), true);
+  var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1, "callback");
+  assert.equal(pcccbh.isPubControlClientCallbackHandler(), true);
 })();
 
 (function testOneCallSuccess() {
-    var wasCallbackCalled = false;
-    var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1,
-            function(result, error, context) {
-                assert(result);
-                assert.equal(error, null);
-                assert.equal(context, null);
-                wasCallbackCalled = true;
-            });
-    pcccbh.pubControlClientCallbackHandler(true);
-    assert(wasCallbackCalled);
+  var wasCallbackCalled = false;
+  var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1, function(
+    result,
+    error,
+    context
+  ) {
+    assert(result);
+    assert.equal(error, null);
+    assert.equal(context, null);
+    wasCallbackCalled = true;
+  });
+  pcccbh.pubControlClientCallbackHandler(true);
+  assert(wasCallbackCalled);
 })();
 
 (function testThreeCallSuccess() {
-    var wasCallbackCalled = false;
-    var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(3,
-            function(result, error, context) {
-                assert(result);
-                assert.equal(error, null);
-                assert.equal(context, null);
-                wasCallbackCalled = true;
-            });
-    pcccbh.pubControlClientCallbackHandler(true);
-    assert(!wasCallbackCalled);
-    pcccbh.pubControlClientCallbackHandler(true);
-    assert(!wasCallbackCalled);
-    pcccbh.pubControlClientCallbackHandler(true);
-    assert(wasCallbackCalled);
+  var wasCallbackCalled = false;
+  var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(3, function(
+    result,
+    error,
+    context
+  ) {
+    assert(result);
+    assert.equal(error, null);
+    assert.equal(context, null);
+    wasCallbackCalled = true;
+  });
+  pcccbh.pubControlClientCallbackHandler(true);
+  assert(!wasCallbackCalled);
+  pcccbh.pubControlClientCallbackHandler(true);
+  assert(!wasCallbackCalled);
+  pcccbh.pubControlClientCallbackHandler(true);
+  assert(wasCallbackCalled);
 })();
 
 (function testOneCallFailure() {
-    var wasCallbackCalled = false;
-    var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1,
-            function(result, error, context) {
-                assert(!result);
-                assert.equal(error, 'error');
-                assert.equal(context, 'context');
-                wasCallbackCalled = true;
-            });
-    pcccbh.pubControlClientCallbackHandler(false, 'error', 'context');
-    assert(wasCallbackCalled);
+  var wasCallbackCalled = false;
+  var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(1, function(
+    result,
+    error,
+    context
+  ) {
+    assert(!result);
+    assert.equal(error, "error");
+    assert.equal(context, "context");
+    wasCallbackCalled = true;
+  });
+  pcccbh.pubControlClientCallbackHandler(false, "error", "context");
+  assert(wasCallbackCalled);
 })();
 
 (function testThreeCallFailure() {
-    var wasCallbackCalled = false;
-    var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(3,
-            function(result, error, context) {
-                assert(!result);
-                assert.equal(error, 'error');
-                assert.equal(context, 'context');
-                wasCallbackCalled = true;
-            });
-    pcccbh.pubControlClientCallbackHandler(false, 'error', 'context');
-    assert(!wasCallbackCalled);
-    pcccbh.pubControlClientCallbackHandler(true);
-    assert(!wasCallbackCalled);
-    pcccbh.pubControlClientCallbackHandler(false, 'error2', 'context2');
-    assert(wasCallbackCalled);
+  var wasCallbackCalled = false;
+  var pcccbh = new pcccbHandler.PubControlClientCallbackHandler(3, function(
+    result,
+    error,
+    context
+  ) {
+    assert(!result);
+    assert.equal(error, "error");
+    assert.equal(context, "context");
+    wasCallbackCalled = true;
+  });
+  pcccbh.pubControlClientCallbackHandler(false, "error", "context");
+  assert(!wasCallbackCalled);
+  pcccbh.pubControlClientCallbackHandler(true);
+  assert(!wasCallbackCalled);
+  pcccbh.pubControlClientCallbackHandler(false, "error2", "context2");
+  assert(wasCallbackCalled);
 })();

--- a/tests/pubcontrol_tests.js
+++ b/tests/pubcontrol_tests.js
@@ -1,99 +1,101 @@
 #!/usr/bin/env node
-var assert = require('assert');
-var util = require('util');
-var pubcontrol = require('../lib/pubcontrol')
+var assert = require("assert");
+var util = require("util");
+var pubcontrol = require("../lib/pubcontrol");
 
-var TestFormat = function(body) { this.body = body; };
+var TestFormat = function(body) {
+  this.body = body;
+};
 util.inherits(TestFormat, pubcontrol.Format);
-TestFormat.prototype.name = function() { return 'testformat'; };
-TestFormat.prototype.export = function() { return {'body': this.body}; };
+TestFormat.prototype.name = function() {
+  return "testformat";
+};
+TestFormat.prototype.export = function() {
+  return { body: this.body };
+};
 var TestItem = new pubcontrol.Item();
 
 (function testInitialize() {
-    var pc = new pubcontrol.PubControl();
-    assert.equal(pc.clients.length, 0);
-    var pc = new pubcontrol.PubControl({ 'uri': 'uri',
-            'iss': 'iss',
-            'key': 'key==' });
-    assert.equal(pc.clients.length, 1);
+  var pc = new pubcontrol.PubControl();
+  assert.equal(pc.clients.length, 0);
+  var pc = new pubcontrol.PubControl({ uri: "uri", iss: "iss", key: "key==" });
+  assert.equal(pc.clients.length, 1);
 })();
 
 (function testRemoveAllClients() {
-    var pc = new pubcontrol.PubControl({ 'uri': 'uri',
-            'iss': 'iss',
-            'key': 'key==' });
-    assert.equal(pc.clients.length, 1);
-    pc.removeAllClients();
-    assert.equal(pc.clients.length, 0);
+  var pc = new pubcontrol.PubControl({ uri: "uri", iss: "iss", key: "key==" });
+  assert.equal(pc.clients.length, 1);
+  pc.removeAllClients();
+  assert.equal(pc.clients.length, 0);
 })();
 
 (function testAddClient() {
-    var pc = new pubcontrol.PubControl({ 'uri': 'uri',
-            'iss': 'iss',
-            'key': 'key==' });
-    assert.equal(pc.clients.length, 1);
-    pc.addClient(new pubcontrol.PubControlClient('uri'));
-    assert.equal(pc.clients.length, 2);
+  var pc = new pubcontrol.PubControl({ uri: "uri", iss: "iss", key: "key==" });
+  assert.equal(pc.clients.length, 1);
+  pc.addClient(new pubcontrol.PubControlClient("uri"));
+  assert.equal(pc.clients.length, 2);
 })();
 
 (function testApplyConfig() {
-    var pc = new pubcontrol.PubControl();
-    pc.applyConfig({ 'uri': 'uri',
-            'iss': 'iss',
-            'key': 'key==' });
-    assert.equal(pc.clients.length, 1);
-    assert.equal(pc.clients[0].uri, 'uri');
-    assert.equal(pc.clients[0].auth.claim['iss'], 'iss');
-    assert.equal(pc.clients[0].auth.key, 'key==');
-    pc.applyConfig([{ 'uri': 'uri2',
-            'iss': 'iss2',
-            'key': 'key==2' },
-          { 'uri': 'uri3',
-            'iss': 'iss3',
-            'key': 'key==3'}]);
-    assert.equal(pc.clients.length, 3);
-    assert.equal(pc.clients[0].uri, 'uri');
-    assert.equal(pc.clients[0].auth.claim['iss'], 'iss');
-    assert.equal(pc.clients[0].auth.key, 'key==');
-    assert.equal(pc.clients[1].uri, 'uri2');
-    assert.equal(pc.clients[1].auth.claim['iss'], 'iss2');
-    assert.equal(pc.clients[1].auth.key, 'key==2');
-    assert.equal(pc.clients[2].uri, 'uri3');
-    assert.equal(pc.clients[2].auth.claim['iss'], 'iss3');
-    assert.equal(pc.clients[2].auth.key, 'key==3');
+  var pc = new pubcontrol.PubControl();
+  pc.applyConfig({ uri: "uri", iss: "iss", key: "key==" });
+  assert.equal(pc.clients.length, 1);
+  assert.equal(pc.clients[0].uri, "uri");
+  assert.equal(pc.clients[0].auth.claim["iss"], "iss");
+  assert.equal(pc.clients[0].auth.key, "key==");
+  pc.applyConfig([
+    { uri: "uri2", iss: "iss2", key: "key==2" },
+    { uri: "uri3", iss: "iss3", key: "key==3" }
+  ]);
+  assert.equal(pc.clients.length, 3);
+  assert.equal(pc.clients[0].uri, "uri");
+  assert.equal(pc.clients[0].auth.claim["iss"], "iss");
+  assert.equal(pc.clients[0].auth.key, "key==");
+  assert.equal(pc.clients[1].uri, "uri2");
+  assert.equal(pc.clients[1].auth.claim["iss"], "iss2");
+  assert.equal(pc.clients[1].auth.key, "key==2");
+  assert.equal(pc.clients[2].uri, "uri3");
+  assert.equal(pc.clients[2].auth.claim["iss"], "iss3");
+  assert.equal(pc.clients[2].auth.key, "key==3");
 })();
 
 (function testPublish() {
-    var wasPublishCalled = false;
-    var pc = new pubcontrol.PubControl();
-    pc.addClient({ publish: function(channel, item, callback) {
-        assert.equal(item, 'item');
-        assert.equal(channel, 'chan');
-        assert.equal(callback, null);   
-        wasPublishCalled = true;
-    }});
-    pc.publish('chan', 'item');
-    assert(wasPublishCalled);
+  var wasPublishCalled = false;
+  var pc = new pubcontrol.PubControl();
+  pc.addClient({
+    publish: function(channel, item, callback) {
+      assert.equal(item, "item");
+      assert.equal(channel, "chan");
+      assert.equal(callback, null);
+      wasPublishCalled = true;
+    }
+  });
+  pc.publish("chan", "item");
+  assert(wasPublishCalled);
 })();
 
 (function testPublishCallback() {
-    var callback = function() {};
-    var wasPublishCalled = false;
-    var pc = new pubcontrol.PubControl();
-    pc.addClient({ publish: function(channel, item, cb) {
-        assert.equal(item, 'item');
-        assert.equal(channel, 'chan');
-        assert.equal(cb.numCalls, 2);   
-        assert.equal(cb.callback, callback);   
-        wasPublishCalled = true;
-    }});
-    pc.addClient({ publish: function(channel, item, cb) {
-        assert.equal(item, 'item');
-        assert.equal(channel, 'chan');
-        assert.equal(cb.numCalls, 2);   
-        assert.equal(cb.callback, callback); 
-        wasPublishCalled = true;
-    }});
-    pc.publish('chan', 'item', callback);
-    assert(wasPublishCalled);
+  var callback = function() {};
+  var wasPublishCalled = false;
+  var pc = new pubcontrol.PubControl();
+  pc.addClient({
+    publish: function(channel, item, cb) {
+      assert.equal(item, "item");
+      assert.equal(channel, "chan");
+      assert.equal(cb.numCalls, 2);
+      assert.equal(cb.callback, callback);
+      wasPublishCalled = true;
+    }
+  });
+  pc.addClient({
+    publish: function(channel, item, cb) {
+      assert.equal(item, "item");
+      assert.equal(channel, "chan");
+      assert.equal(cb.numCalls, 2);
+      assert.equal(cb.callback, callback);
+      wasPublishCalled = true;
+    }
+  });
+  pc.publish("chan", "item", callback);
+  assert(wasPublishCalled);
 })();

--- a/tests/pubcontrolclient_tests.js
+++ b/tests/pubcontrolclient_tests.js
@@ -1,233 +1,255 @@
 #!/usr/bin/env node
-var assert = require('assert');
-var util = require('util');
-var pubControlClient = require('../lib/pubcontrolclient');
-var format = require('../lib/format');
-var item = require('../lib/item');
-var utilities = require('../lib/utilities');
+var assert = require("assert");
+var util = require("util");
+var pubControlClient = require("../lib/pubcontrolclient");
+var format = require("../lib/format");
+var item = require("../lib/item");
+var utilities = require("../lib/utilities");
 
-var TestFormat = function(body) { this.body = body; };
+var TestFormat = function(body) {
+  this.body = body;
+};
 util.inherits(TestFormat, format.Format);
-TestFormat.prototype.name = function() { return 'testformat'; };
-TestFormat.prototype.export = function() { return {'body': this.body}; };
+TestFormat.prototype.name = function() {
+  return "testformat";
+};
+TestFormat.prototype.export = function() {
+  return { body: this.body };
+};
 
 (function testInitialize() {
-    var pcc = new pubControlClient.PubControlClient('uri');
-    assert.equal(pcc.uri, 'uri');
-    assert.equal(pcc.auth, null);
-    assert.notEqual(pcc.httpKeepAliveAgent, null);
-    assert.notEqual(pcc.httpsKeepAliveAgent, null);
+  var pcc = new pubControlClient.PubControlClient("uri");
+  assert.equal(pcc.uri, "uri");
+  assert.equal(pcc.auth, null);
+  assert.notEqual(pcc.httpKeepAliveAgent, null);
+  assert.notEqual(pcc.httpsKeepAliveAgent, null);
 })();
 
 (function testSetAuthBasic() {
-    var pcc = new pubControlClient.PubControlClient('uri');
-    pcc.setAuthBasic('user', 'pass');
-    assert.equal(pcc.auth.user, 'user');
-    assert.equal(pcc.auth.pass, 'pass');
+  var pcc = new pubControlClient.PubControlClient("uri");
+  pcc.setAuthBasic("user", "pass");
+  assert.equal(pcc.auth.user, "user");
+  assert.equal(pcc.auth.pass, "pass");
 })();
 
 (function testSetAuthJwt() {
-    var pcc = new pubControlClient.PubControlClient('uri');
-    pcc.setAuthJwt('claim', 'key');
-    assert.equal(pcc.auth.claim, 'claim');
-    assert.equal(pcc.auth.key, 'key');
-    pcc = new pubControlClient.PubControlClient('uri');
-    pcc.setAuthJwt('token');
-    assert.equal(pcc.auth.token, 'token');
+  var pcc = new pubControlClient.PubControlClient("uri");
+  pcc.setAuthJwt("claim", "key");
+  assert.equal(pcc.auth.claim, "claim");
+  assert.equal(pcc.auth.key, "key");
+  pcc = new pubControlClient.PubControlClient("uri");
+  pcc.setAuthJwt("token");
+  assert.equal(pcc.auth.token, "token");
 })();
 
 (function testPublish() {
-    var wasWorkerCalled = false;
-    var itm = new item.Item(new TestFormat('bodyval', 'id',
-            'prev-id'));
-    var exportedItem = itm.export();
-    exportedItem['channel'] = 'channel';
-    var pcc = new pubControlClient.PubControlClient('uri');
-    pcc.startPubCall = function(uri, authHeader,
-            items, cb) {
-        assert.equal(uri, 'uri');
-        assert.equal(authHeader, 'Basic ' +
-                Buffer.from('user:pass').toString('base64'));
-        assert.equal(JSON.stringify(items), JSON.stringify([exportedItem]));
-        assert.equal(cb, 'callback');
-        wasWorkerCalled = true;
-    };
-    pcc.setAuthBasic('user', 'pass');
-    pcc.publish('channel', itm, 'callback');
-    assert(wasWorkerCalled);
+  var wasWorkerCalled = false;
+  var itm = new item.Item(new TestFormat("bodyval", "id", "prev-id"));
+  var exportedItem = itm.export();
+  exportedItem["channel"] = "channel";
+  var pcc = new pubControlClient.PubControlClient("uri");
+  pcc.startPubCall = function(uri, authHeader, items, cb) {
+    assert.equal(uri, "uri");
+    assert.equal(
+      authHeader,
+      "Basic " + Buffer.from("user:pass").toString("base64")
+    );
+    assert.equal(JSON.stringify(items), JSON.stringify([exportedItem]));
+    assert.equal(cb, "callback");
+    wasWorkerCalled = true;
+  };
+  pcc.setAuthBasic("user", "pass");
+  pcc.publish("channel", itm, "callback");
+  assert(wasWorkerCalled);
 })();
 
 (function testPublishNoAuth() {
-    var wasWorkerCalled = false;
-    var itm = new item.Item(new TestFormat('bodyval', 'id',
-            'prev-id'));
-    var exportedItem = itm.export();
-    exportedItem['channel'] = 'channel';
-    var pcc = new pubControlClient.PubControlClient('uri');
-    pcc.startPubCall = function(uri, authHeader,
-            items, cb) {
-        assert.equal(uri, 'uri');
-        assert.equal(authHeader, null);
-        assert.equal(JSON.stringify(items), JSON.stringify([exportedItem]));
-        assert.equal(cb, 'callback');
-        wasWorkerCalled = true;
-    };
-    pcc.publish('channel', itm, 'callback');
-    assert(wasWorkerCalled);
+  var wasWorkerCalled = false;
+  var itm = new item.Item(new TestFormat("bodyval", "id", "prev-id"));
+  var exportedItem = itm.export();
+  exportedItem["channel"] = "channel";
+  var pcc = new pubControlClient.PubControlClient("uri");
+  pcc.startPubCall = function(uri, authHeader, items, cb) {
+    assert.equal(uri, "uri");
+    assert.equal(authHeader, null);
+    assert.equal(JSON.stringify(items), JSON.stringify([exportedItem]));
+    assert.equal(cb, "callback");
+    wasWorkerCalled = true;
+  };
+  pcc.publish("channel", itm, "callback");
+  assert(wasWorkerCalled);
 })();
 
 (function testStartPubCall() {
-    var pcc = new pubControlClient.PubControlClient('http://uri.com');
-    var wasPerformHttpRequestCalled = false;
-    pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
-        assert.equal(reqParams.body, JSON.stringify({'items': 'items'}));
-        assert.equal(typeof cb, "function")
-        assert.equal(reqParams.method, 'POST');
-        assert.equal(reqParams.headers['Content-Type'], 'application/json');
-        assert.equal(reqParams.headers['Content-Length'],
-                Buffer.byteLength(reqParams.body, 'utf8'));
-        assert.equal(reqParams.headers['Authorization'], 'authHeader');
-        assert.equal(uri, 'http://uri.com/publish/');
-        assert.equal(pcc.httpKeepAliveAgent, reqParams.agent);
-        wasPerformHttpRequestCalled = true;
-    };
-    pcc.startPubCall('http://uri.com', 'authHeader', 'items', function(){});
-    assert(wasPerformHttpRequestCalled);
+  var pcc = new pubControlClient.PubControlClient("http://uri.com");
+  var wasPerformHttpRequestCalled = false;
+  pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
+    assert.equal(reqParams.body, JSON.stringify({ items: "items" }));
+    assert.equal(typeof cb, "function");
+    assert.equal(reqParams.method, "POST");
+    assert.equal(reqParams.headers["Content-Type"], "application/json");
+    assert.equal(
+      reqParams.headers["Content-Length"],
+      Buffer.byteLength(reqParams.body, "utf8")
+    );
+    assert.equal(reqParams.headers["Authorization"], "authHeader");
+    assert.equal(uri, "http://uri.com/publish/");
+    assert.equal(pcc.httpKeepAliveAgent, reqParams.agent);
+    wasPerformHttpRequestCalled = true;
+  };
+  pcc.startPubCall("http://uri.com", "authHeader", "items", function() {});
+  assert(wasPerformHttpRequestCalled);
 })();
 
 (function testStartPubCallHttps() {
-    var pcc = new pubControlClient.PubControlClient('https://uri.com');
-    var wasPerformHttpRequestCalled = false;
-    pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
-        assert.equal(reqParams.body, JSON.stringify({'items': 'items'}));
-        assert.equal(typeof cb, "function")
-        assert.equal(reqParams.method, 'POST');
-        assert.equal(reqParams.headers['Content-Type'], 'application/json');
-        assert.equal(reqParams.headers['Content-Length'],
-                Buffer.byteLength(reqParams.body, 'utf8'));
-        assert(!('Authorization' in reqParams.headers));
-        assert.equal(uri, 'https://uri.com/publish/');
-        assert.equal(pcc.httpsKeepAliveAgent, reqParams.agent);
-        wasPerformHttpRequestCalled = true;
-    };
-    pcc.startPubCall('https://uri.com', null, 'items', function() {});
-    assert(wasPerformHttpRequestCalled);
+  var pcc = new pubControlClient.PubControlClient("https://uri.com");
+  var wasPerformHttpRequestCalled = false;
+  pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
+    assert.equal(reqParams.body, JSON.stringify({ items: "items" }));
+    assert.equal(typeof cb, "function");
+    assert.equal(reqParams.method, "POST");
+    assert.equal(reqParams.headers["Content-Type"], "application/json");
+    assert.equal(
+      reqParams.headers["Content-Length"],
+      Buffer.byteLength(reqParams.body, "utf8")
+    );
+    assert(!("Authorization" in reqParams.headers));
+    assert.equal(uri, "https://uri.com/publish/");
+    assert.equal(pcc.httpsKeepAliveAgent, reqParams.agent);
+    wasPerformHttpRequestCalled = true;
+  };
+  pcc.startPubCall("https://uri.com", null, "items", function() {});
+  assert(wasPerformHttpRequestCalled);
 })();
 
 (function testStartPubCallBadUri() {
-    var pcc = new pubControlClient.PubControlClient('https://uri.com');
-    var wasCallbackCalled = false;
-    pcc.startPubCall('file://uri.com', null, 'items', function(status,
-            message, context) {
-        assert.equal(status, false);
-        assert.equal(message, 'Bad URI');
-        assert.equal(context.statusCode, -2);
-        wasCallbackCalled = true;
-    });
-    setTimeout(function() { assert(wasCallbackCalled); }, 500);
+  var pcc = new pubControlClient.PubControlClient("https://uri.com");
+  var wasCallbackCalled = false;
+  pcc.startPubCall("file://uri.com", null, "items", function(
+    status,
+    message,
+    context
+  ) {
+    assert.equal(status, false);
+    assert.equal(message, "Bad URI");
+    assert.equal(context.statusCode, -2);
+    wasCallbackCalled = true;
+  });
+  setTimeout(function() {
+    assert(wasCallbackCalled);
+  }, 500);
 })();
 
 (function testFinishHttpRequest() {
-    var pcc = new pubControlClient.PubControlClient('https://uri.com');
-    var wasCallbackCalled = false;
-    pcc.finishHttpRequest('end', function(status, message, context) {
-        assert.equal(status, true);
-        assert.equal(message, '');
-        assert.equal(context.statusCode, 200);
-        wasCallbackCalled = true;
-    }, ['result'], { statusCode: 200 });
-    assert(wasCallbackCalled);
+  var pcc = new pubControlClient.PubControlClient("https://uri.com");
+  var wasCallbackCalled = false;
+  pcc.finishHttpRequest(
+    "end",
+    function(status, message, context) {
+      assert.equal(status, true);
+      assert.equal(message, "");
+      assert.equal(context.statusCode, 200);
+      wasCallbackCalled = true;
+    },
+    ["result"],
+    { statusCode: 200 }
+  );
+  assert(wasCallbackCalled);
 })();
 
 (function testFinishHttpRequestFailure() {
-    var pcc = new pubControlClient.PubControlClient('https://uri.com');
-    var wasCallbackCalled = false;
-    pcc.finishHttpRequest('end', function(status, message, context) {
-        assert.equal(status, false);
-        assert.equal(message, JSON.stringify('result'));
-        assert.equal(context.statusCode, 300);
-        wasCallbackCalled = true;
-    }, 'result', { statusCode: 300 });
-    assert(wasCallbackCalled);
+  var pcc = new pubControlClient.PubControlClient("https://uri.com");
+  var wasCallbackCalled = false;
+  pcc.finishHttpRequest(
+    "end",
+    function(status, message, context) {
+      assert.equal(status, false);
+      assert.equal(message, JSON.stringify("result"));
+      assert.equal(context.statusCode, 300);
+      wasCallbackCalled = true;
+    },
+    "result",
+    { statusCode: 300 }
+  );
+  assert(wasCallbackCalled);
 })();
 
 (function testFinishHttpRequestClose() {
-    var pcc = new pubControlClient.PubControlClient('https://uri.com');
-    var wasCallbackCalled = false;
-    pcc.finishHttpRequest('close', function(status, message, context) {
-        assert.equal(status, false);
-        assert.equal(message, 'Connection closed unexpectedly');
-        assert.equal(context.statusCode, 300);
-        wasCallbackCalled = true;
-    }, 'result', { statusCode: 300 });
-    assert(wasCallbackCalled);
+  var pcc = new pubControlClient.PubControlClient("https://uri.com");
+  var wasCallbackCalled = false;
+  pcc.finishHttpRequest(
+    "close",
+    function(status, message, context) {
+      assert.equal(status, false);
+      assert.equal(message, "Connection closed unexpectedly");
+      assert.equal(context.statusCode, 300);
+      wasCallbackCalled = true;
+    },
+    "result",
+    { statusCode: 300 }
+  );
+  assert(wasCallbackCalled);
 })();
 
 (function testPerformHttpRequest() {
-    var wasFinishHttpRequestCalled = false;
-    var wasFinishHttpRequestCalledForClose = false;
-    var pcc = new pubControlClient.PubControlClient('https://uri.com');
+  var wasFinishHttpRequestCalled = false;
+  var wasFinishHttpRequestCalledForClose = false;
+  var pcc = new pubControlClient.PubControlClient("https://uri.com");
 
-    var doFail = true;
+  var doFail = true;
 
-    pcc.finishHttpRequest = function(mode, cb, httpData, context) {
-        assert.equal(httpData, 'result');
-        assert.equal(cb, callback);
-        if (mode == 'end') {
-            wasFinishHttpRequestCalled = true;
-        }
-        if (mode == 'close') {
-            wasFinishHttpRequestCalledForClose = true;
-        }
-    };
-
-    var transport = function (uri, opts) {
-        return new Promise(function (resolve, reject) {
-            assert.equal(opts.body, 'content');
-
-            if (doFail) {
-                reject({ message: 'message' })
-            } else {
-                resolve({
-                    status: 200,
-                    headers: {},
-                    text: function () {
-                        return new Promise(function (resolve) {
-                            resolve('result');
-                        });
-                    }
-                });
-            }
-        });
-    };
-
-    var callback = function(status, message, context) {
-        if (doFail) {
-            assert.equal(status, false);
-            assert.equal(message, 'message');
-            assert.equal(context.statusCode, -1);
-
-            assert(!wasFinishHttpRequestCalled);
-            assert(!wasFinishHttpRequestCalledForClose);
-
-            doFail = false;
-
-            pcc.performHttpRequest(
-                callback,
-                transport,
-                'https://uri.com/publish/',
-                {body: 'content'}
-            );
-        } else {
-            assert(wasFinishHttpRequestCalled);
-            assert(wasFinishHttpRequestCalledForClose);
-        }
+  pcc.finishHttpRequest = function(mode, cb, httpData, context) {
+    assert.equal(httpData, "result");
+    assert.equal(cb, callback);
+    if (mode == "end") {
+      wasFinishHttpRequestCalled = true;
     }
+    if (mode == "close") {
+      wasFinishHttpRequestCalledForClose = true;
+    }
+  };
 
-    pcc.performHttpRequest(
-        callback,
-        transport,
-        'https://uri.com/publish/',
-        {body: 'content'}
-    );
+  var transport = function(uri, opts) {
+    return new Promise(function(resolve, reject) {
+      assert.equal(opts.body, "content");
+
+      if (doFail) {
+        reject({ message: "message" });
+      } else {
+        resolve({
+          status: 200,
+          headers: {},
+          text: function() {
+            return new Promise(function(resolve) {
+              resolve("result");
+            });
+          }
+        });
+      }
+    });
+  };
+
+  var callback = function(status, message, context) {
+    if (doFail) {
+      assert.equal(status, false);
+      assert.equal(message, "message");
+      assert.equal(context.statusCode, -1);
+
+      assert(!wasFinishHttpRequestCalled);
+      assert(!wasFinishHttpRequestCalledForClose);
+
+      doFail = false;
+
+      pcc.performHttpRequest(callback, transport, "https://uri.com/publish/", {
+        body: "content"
+      });
+    } else {
+      assert(wasFinishHttpRequestCalled);
+      assert(wasFinishHttpRequestCalledForClose);
+    }
+  };
+
+  pcc.performHttpRequest(callback, transport, "https://uri.com/publish/", {
+    body: "content"
+  });
 })();

--- a/tests/pubcontrolclient_tests.js
+++ b/tests/pubcontrolclient_tests.js
@@ -47,7 +47,7 @@ TestFormat.prototype.export = function() { return {'body': this.body}; };
             items, cb) {
         assert.equal(uri, 'uri');
         assert.equal(authHeader, 'Basic ' +
-                new Buffer('user:pass').toString('base64'));
+                Buffer.from('user:pass').toString('base64'));
         assert.equal(JSON.stringify(items), JSON.stringify([exportedItem]));
         assert.equal(cb, 'callback');
         wasWorkerCalled = true;

--- a/tests/pubcontrolclient_tests.js
+++ b/tests/pubcontrolclient_tests.js
@@ -81,7 +81,7 @@ TestFormat.prototype.export = function() { return {'body': this.body}; };
     var wasPerformHttpRequestCalled = false;
     pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
         assert.equal(reqParams.body, JSON.stringify({'items': 'items'}));
-        assert(utilities.isFunction(cb));
+        assert.equal(typeof cb, "function")
         assert.equal(reqParams.method, 'POST');
         assert.equal(reqParams.headers['Content-Type'], 'application/json');
         assert.equal(reqParams.headers['Content-Length'],
@@ -100,7 +100,7 @@ TestFormat.prototype.export = function() { return {'body': this.body}; };
     var wasPerformHttpRequestCalled = false;
     pcc.performHttpRequest = function(cb, transport, uri, reqParams) {
         assert.equal(reqParams.body, JSON.stringify({'items': 'items'}));
-        assert(utilities.isFunction(cb));
+        assert.equal(typeof cb, "function")
         assert.equal(reqParams.method, 'POST');
         assert.equal(reqParams.headers['Content-Type'], 'application/json');
         assert.equal(reqParams.headers['Content-Length'],

--- a/tests/utilities_tests.js
+++ b/tests/utilities_tests.js
@@ -3,11 +3,6 @@ var assert = require('assert');
 var utilities = require('../lib/utilities');
 var pcccbHandler = require('../lib/pcccbhandler');
 
-(function testIsFunction() {
-    assert(!(utilities.isFunction('hello')));
-    assert(utilities.isFunction(function(){}));
-})();
-
 (function testToBuffer() {
     var buf = new Buffer('hello');
     assert.equal(buf, utilities.toBuffer(buf));

--- a/tests/utilities_tests.js
+++ b/tests/utilities_tests.js
@@ -1,29 +1,40 @@
 #!/usr/bin/env node
-var assert = require('assert');
-var utilities = require('../lib/utilities');
-var pcccbHandler = require('../lib/pcccbhandler');
+var assert = require("assert");
+var utilities = require("../lib/utilities");
+var pcccbHandler = require("../lib/pcccbhandler");
 
 (function testApplyCallback() {
-    var wasCallbackCalled = false;
-    utilities.applyCallback('status', function(status, message,
-            context) {
-                assert.equal(status, 'status');
-                assert.equal(message, 'message');
-                assert.equal(context, 'context');
-                wasCallbackCalled = true;
-            }, 'message', 'context');
-    assert(wasCallbackCalled);
+  var wasCallbackCalled = false;
+  utilities.applyCallback(
+    "status",
+    function(status, message, context) {
+      assert.equal(status, "status");
+      assert.equal(message, "message");
+      assert.equal(context, "context");
+      wasCallbackCalled = true;
+    },
+    "message",
+    "context"
+  );
+  assert(wasCallbackCalled);
 })();
 
 (function testApplyCallbackPcccbHandler() {
-    var wasCallbackCalled = false;
-    utilities.applyCallback(false, new pcccbHandler.
-            PubControlClientCallbackHandler(1, function(status,
-                    message, context) {
-                assert.equal(status, false);
-                assert.equal(message, 'message');
-                assert.equal(context, 'context');
-                wasCallbackCalled = true;
-            }), 'message', 'context');
-    assert(wasCallbackCalled);
+  var wasCallbackCalled = false;
+  utilities.applyCallback(
+    false,
+    new pcccbHandler.PubControlClientCallbackHandler(1, function(
+      status,
+      message,
+      context
+    ) {
+      assert.equal(status, false);
+      assert.equal(message, "message");
+      assert.equal(context, "context");
+      wasCallbackCalled = true;
+    }),
+    "message",
+    "context"
+  );
+  assert(wasCallbackCalled);
 })();

--- a/tests/utilities_tests.js
+++ b/tests/utilities_tests.js
@@ -8,11 +8,6 @@ var pcccbHandler = require('../lib/pcccbhandler');
     assert(utilities.isFunction(function(){}));
 })();
 
-(function testIsArray() {
-    assert(!(utilities.isArray('hello')));
-    assert(utilities.isArray([]));
-})();
-
 (function testToBuffer() {
     var buf = new Buffer('hello');
     assert.equal(buf, utilities.toBuffer(buf));

--- a/tests/utilities_tests.js
+++ b/tests/utilities_tests.js
@@ -3,14 +3,6 @@ var assert = require('assert');
 var utilities = require('../lib/utilities');
 var pcccbHandler = require('../lib/pcccbhandler');
 
-(function testToBuffer() {
-    var buf = new Buffer('hello');
-    assert.equal(buf, utilities.toBuffer(buf));
-    buf = utilities.toBuffer('hello');
-    assert(Buffer.isBuffer(buf));
-    assert(buf.toString(), 'hello');
-})();
-
 (function testApplyCallback() {
     var wasCallbackCalled = false;
     utilities.applyCallback('status', function(status, message,


### PR DESCRIPTION
Merge this after: https://github.com/fanout/node-pubcontrol/pull/8

This one has added and ran `npm run lint:eslint:fix` which fixed a bunch of indentation in tests.

But because so much indentation changed, I didn't want to make the diff on #8 garbled. Hence this extra PR.